### PR TITLE
Carson/mupdf_debug_symbols

### DIFF
--- a/Dockerfile.demo
+++ b/Dockerfile.demo
@@ -11,7 +11,7 @@ WORKDIR /polytracker/the_klondike/mupdf
 
 RUN git submodule update --init
 
-RUN make -j$((`nproc`+1)) HAVE_X11=no HAVE_GLUT=no prefix=./bin install
+RUN make -j$((`nproc`+1)) HAVE_X11=no HAVE_GLUT=no prefix=/usr/local debug
 
 RUN mkdir -p /workdir
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ cd mupdf
 git submodule update --init
 make -j10 HAVE_X11=no HAVE_GLUT=no prefix=./bin install
 ``` 
+
+Or if you would like to build the debug version, as we do in our Dockerfile:
+
+```
+make -j10 HAVE_X11=no HAVE_GLUT=no prefix=./bin debug
+```
+
 ## Enviornment Variables 
 
 PolyTracker accepts configuration paramters in the form of enviornment variables to avoid recompiling target programs. The current enviornment variables PolyTracker supports is: 


### PR DESCRIPTION
This just changes the dockerfile to build with debug symbols, and updated some place in the readme 