### PR TITLE
Make sure mutexes are consistently used in polytracker

### DIFF
--- a/polytracker/dfsan/dfsan_rt/dfsan/dfsan.cc
+++ b/polytracker/dfsan/dfsan_rt/dfsan/dfsan.cc
@@ -74,6 +74,8 @@ SANITIZER_INTERFACE_ATTRIBUTE uptr __dfsan_shadow_ptr_mask;
 std::unordered_map<std::thread::id, std::vector<std::string>> * thread_stack_map;
 
 static uptr forest_base_addr = MappingArchImpl<MAPPING_TAINT_FOREST_ADDR>();
+/* Note: this is a pointer on purpose, to avoid any complications from ordering
+ * of destructors of static objects */
 static std::unordered_map<std::string, std::unordered_set<taint_node_t*>> *function_to_bytes;
 static std::unordered_map<dfsan_label, std::unordered_map<dfsan_label, dfsan_label>> union_table;
 static std::mutex function_to_bytes_mutex; 


### PR DESCRIPTION
In the future, we might consider using just a single mutex for all polytracker internals, since once you start dealing with multiple locks, you have to worry about deadlock.

Fixes #25.