### PR TITLE
Carson/fgetc tainted blocks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,13 +18,29 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y update  \
       git                                             \
       lld-7                                           \
       llvm-7                                          \
+			libc++abi-dev																		\
       ninja-build                                     \
-      python3-pip                                     \
-      python3.7
+			python3-pip																			\
+      python3.7-dev																		\
+			golang																					\
+			libgraphviz-dev
+
+RUN python3.7 -m pip install pip
+
+RUN go get github.com/SRI-CSL/gllvm/cmd/...
+
+ENV PATH="$PATH:/root/go/bin"
 
 COPY . /polytracker
 
 WORKDIR /polytracker
+
+RUN python3.7 -m pip install pytest
+
+RUN python3.7 -m pip install .
+
+RUN rm /usr/bin/python3 
+RUN cp /usr/bin/python3.7 /usr/bin/python3
 
 RUN rm -rf build && mkdir -p build
 
@@ -36,4 +52,4 @@ RUN cmake -G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE
 ENV CC=/polytracker/build/bin/polytracker/polyclang
 ENV CXX=/polytracker/build/bin/polytracker/polyclang++
 
-WORKDIR / 
+WORKDIR /polytracker 

--- a/polytracker/src/dfsan_rt/dfsan/dfsan_log_mgmt.cpp
+++ b/polytracker/src/dfsan_rt/dfsan/dfsan_log_mgmt.cpp
@@ -226,6 +226,8 @@ dfsan_label taintManager::createReturnLabel(int file_byte_offset,
                                             std::string name) {
   taint_prop_lock.lock();
   dfsan_label ret_label = createCanonicalLabel(file_byte_offset, name);
+  taint_bytes_processed[name].push_back(
+        std::pair<int, int>(file_byte_offset, file_byte_offset));
   taint_prop_lock.unlock();
   return ret_label;
 }

--- a/polytracker/src/dfsan_sources/taint_sources.cpp
+++ b/polytracker/src/dfsan_sources/taint_sources.cpp
@@ -258,6 +258,7 @@ EXT_C_FUNC int __dfsw_fgetc(FILE *fd, dfsan_label fd_label,
   }
   return c;
 }
+
 EXT_C_FUNC int __dfsw_fgetc_unlocked(FILE *fd, dfsan_label fd_label,
                                      dfsan_label *ret_label) {
   long offset = ftell(fd);

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ setup(
         'networkX',
         'tqdm',
         'pygraphviz',
-        'pydot'
+        'pydot',
+        'typing_extensions'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This PR is a minor bugfix, we were not adding parser offset info when reading from single character functions like fgetc. This is fixed now. 