### PR TITLE
Carson/test memcpy

### DIFF
--- a/polyprocess/polyprocess.py
+++ b/polyprocess/polyprocess.py
@@ -55,7 +55,14 @@ class PolyProcess:
         self.json_size = os.path.getsize(polytracker_json_path)
         self.polytracker_json = json.loads(self.json_file.read(self.json_size))
         self.processed_taint_sets: Dict[str, Dict[str, Dict[str, List[int]]]] = {}
-        self.taint_sets = self.polytracker_json["tainted_functions"]
+        if "tainted_functions" not in self.polytracker_json:
+            self.taint_sets = None
+        else:
+            self.taint_sets = self.polytracker_json["tainted_functions"]
+        if "tainted_input_blocks" not in self.polytracker_json:
+            self.tainted_input_blocks = None
+        else:
+            self.tainted_input_blocks = self.polytracker_json["tainted_input_blocks"]
         self.forest_file = open(polytracker_forest_path, "rb")
         self.forest_file_size = os.path.getsize(polytracker_forest_path)
         self.taint_forest: nx.DiGraph = nx.DiGraph()
@@ -144,6 +151,9 @@ class PolyProcess:
         return self.canonical_mapping[label][0]
 
     def process_taint_sets(self):
+        if self.taint_sets is None:
+            print("Warning! No taint information to process")
+            return
         taint_sets = tqdm(self.taint_sets)
         processed_labels = defaultdict(lambda: defaultdict(lambda: defaultdict(set)))
         for function in taint_sets:

--- a/polytracker/src/dfsan_rt/dfsan/dfsan.cpp
+++ b/polytracker/src/dfsan_rt/dfsan/dfsan.cpp
@@ -120,15 +120,6 @@ extern "C" SANITIZER_INTERFACE_ATTRIBUTE void __dfsan_reset_frame(int *index) {
 void dfsan_late_late_init();
 
 extern "C" SANITIZER_INTERFACE_ATTRIBUTE int __dfsan_func_entry(char *fname) {
-  /*
-        init_lock.lock();
-  if (is_init == false) {
-    dfsan_late_init();
-    is_init = true;
-  }
-  init_lock.unlock();
-  */
-
   init_lock.lock();
   if (is_init == false) {
     dfsan_late_late_init();
@@ -209,13 +200,6 @@ SANITIZER_INTERFACE_ATTRIBUTE dfsan_label dfsan_union(dfsan_label l1,
     return l1;
   return __dfsan_union(l1, l2);
 }
-
-/*
-extern "C" SANITIZER_INTERFACE_ATTRIBUTE
-dfsan_label dfsan_create_canonical_label(int offset) {
-        return taint_prop_manager->createCanonicalLabel(offset);
-}
-*/
 
 extern "C" SANITIZER_INTERFACE_ATTRIBUTE void __dfsan_set_label(
     dfsan_label label, void *addr, uptr size) {
@@ -392,7 +376,7 @@ void dfsan_parse_env() {
     taint_node_ttl = atoi(env_ttl);
   }
 
-  taint_manager->createNewTargetInfo(target_file, byte_start, byte_end);
+  taint_manager->createNewTargetInfo(target_file, byte_start, byte_end - 1);
   // Special tracking for standard input
   taint_manager->createNewTargetInfo("stdin", 0, MAX_LABELS);
   taint_manager->createNewTaintInfo("stdin", stdin);

--- a/tests/test_memcpy.c
+++ b/tests/test_memcpy.c
@@ -1,0 +1,41 @@
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <string.h>
+
+void touch_copied_byte(char * other_buff) {
+	if (other_buff == NULL) {
+		printf("Other buff is null!");
+		return;
+	}
+	//In the testcase, don't process this. We should see the label as canonical
+	//Processing will produce a false positive potentially, so look at taint_sets
+	if (other_buff[0] == 'a') {
+		printf("Other buff is a!");
+		return;
+	}
+	return;
+}
+
+int main(int argc, char * argv[]) {
+	if (argc < 2) {
+		printf("Error, no file specified!");
+	}
+	int fd = open(argv[1], O_RDONLY);
+	if (fd == -1) {
+		printf("Could not open file!\n");
+	}
+	else {
+		char buff[2048];
+		memset(buff, 0, sizeof(buff));
+		char other_buff[2048];
+		memset(other_buff, 0, sizeof(other_buff));
+		int bytes_read = read(fd, buff, 10);
+		memcpy(other_buff, buff, sizeof(other_buff));
+		touch_copied_byte(other_buff);
+		close(fd);
+	}
+	return 0;
+}

--- a/tests/test_no_taint.c
+++ b/tests/test_no_taint.c
@@ -1,0 +1,40 @@
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <string.h>
+
+void touch_copied_byte(char * other_buff) {
+	if (other_buff == NULL) {
+		printf("Other buff is null!");
+		return;
+	}
+	//In the testcase, don't process this. We should see the label as canonical
+	//Processing will produce a false positive potentially, so look at taint_sets
+	if (other_buff[0] == 'a') {
+		printf("Other buff is a!");
+		return;
+	}
+	return;
+}
+
+int main(int argc, char * argv[]) {
+	if (argc < 2) {
+		printf("Error, no file specified!");
+	}
+	int fd = open(argv[1], O_RDONLY);
+	if (fd == -1) {
+		printf("Could not open file!\n");
+	}
+	else {
+		char buff[2048];
+		memset(buff, 0, sizeof(buff));
+		char other_buff[2048];
+		memset(other_buff, 0, sizeof(other_buff));
+		int bytes_read = read(fd, buff, 10);
+		memcpy(other_buff, buff, sizeof(other_buff));
+		close(fd);
+	}
+	return 0;
+}

--- a/tests/test_polytracker.py
+++ b/tests/test_polytracker.py
@@ -3,7 +3,6 @@ import os
 from polyprocess import PolyProcess
 import subprocess
 
-
 TEST_DIR = os.path.realpath(os.path.dirname(__file__))
 BIN_DIR = os.path.join(TEST_DIR, "bin")
 TEST_RESULTS_DIR = os.path.join(BIN_DIR, "test_results")
@@ -105,6 +104,33 @@ def test_source_open():
     pp = validate_execute_target(target_name)
     open_processed_sets = pp.processed_taint_sets
     assert 0 in open_processed_sets["main"]["input_bytes"][test_filename]
+
+
+def test_memcpy_propagate():
+    target_name = "test_memcpy.c"
+    pp = validate_execute_target(target_name)
+    raw_taint_sets = pp.taint_sets
+    print(raw_taint_sets)
+    assert 1 in raw_taint_sets["dfs$touch_copied_byte"]["input_bytes"]
+
+
+def test_no_taint():
+    target_name = "test_no_taint.c"
+    pp = validate_execute_target(target_name)
+    raw_taint_sets = pp.taint_sets
+    assert raw_taint_sets is None
+
+
+# This is a bad name for this test
+# This test compares the taint sources info with the tainted block info
+# When reading an entire file in a single block
+# Basically make sure the start/end match to prevent off-by-one errors
+# TODO
+def test_block_target_values():
+    target_name = "test_memcpy.c"
+    test_filename = "/polytracker/tests/test_data/test_data.txt"
+    pp = validate_execute_target(target_name)
+    assert 0 == 0
 
 
 def test_source_fopen():


### PR DESCRIPTION
This fixes a minor polyprocess bug and adds two new tests

test_memcpy tests to see that memcpy appropriately propagates canonical labels and does not make unions 

test_no_taint tests to see that we handle cases when programs touch no taint appropriately 