### PR TITLE
Scripts to build PolyTracker in an ephemeral Docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 Dockerfile
 build
 *.json
+*.pdf
+.git

--- a/build_in_docker/Dockerfile
+++ b/build_in_docker/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:bionic
+MAINTAINER Evan Sultanik <evan.sultanik@trailofbits.com>
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y update  \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+      wget                                            \
+      gnupg
+
+# Add the LLVM repo for Ubuntu packages, since the official Ubuntu repo has an
+# LLVM that doesn't work right with polytracker for some reason.
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+ && echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main" >>/etc/apt/sources.list
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y update  \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+      clang-7                                         \
+      cmake                                           \
+      git                                             \
+      lld-7                                           \
+      llvm-7                                          \
+			libc++abi-dev							  \
+      ninja-build                                     \
+			golang									  
+
+RUN go get github.com/SRI-CSL/gllvm/cmd/...
+
+ENV PATH="$PATH:/root/go/bin"
+
+RUN mkdir -p /polytracker/build
+
+WORKDIR /polytracker/build
+
+ENV PATH="/usr/lib/llvm-7/bin:${PATH}"
+
+COPY scripts/compile.sh /

--- a/build_in_docker/README.md
+++ b/build_in_docker/README.md
@@ -1,0 +1,16 @@
+# Build PolyTracker in Docker
+
+This directory contains scripts to incrementally build PolyTracker in a Docker container, retaining all build artifacts
+on the host machine. This is intended for incrementally building the project during development.
+
+Simply run:
+
+```console
+$ ./build.sh
+```
+
+from this directory. This script can also safely be called from any other `$PWD`; it will automatically resolve the
+correct path to the PolyTracker root directory.
+
+The script will build a Docker container for compiling PolyTracker (if necessary), and then mount the root
+directory of this repo so all build artifacts will be in the `../build` directory.

--- a/build_in_docker/build.sh
+++ b/build_in_docker/build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if [[ "$(docker images -q trailofbits/polytrackerbuilder 2> /dev/null)" == "" ]]; then
+    docker build -t trailofbits/polytrackerbuilder .
+fi
+
+SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
+mkdir -p "${SCRIPTPATH}/../build"
+
+docker run -ti --rm --mount type=bind,source="${SCRIPTPATH}/..",target=/polytracker trailofbits/polytrackerbuilder:latest /compile.sh

--- a/build_in_docker/scripts/compile.sh
+++ b/build_in_docker/scripts/compile.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+cmake -G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_VERBOSE_MAKEFILE=TRUE .. && ninja install


### PR DESCRIPTION
This adds a script `build_in_docker/build.sh`, which will build (if necessary) a Docker container with the minimum necessary prerequisites to build PolyTracker, and then compile PolyTracker while saving the build artifacts in the `/build` directory of the root of the repository. This allows one to quickly test compilation during development, since all of the development artifacts in `/build` are stored on the host machine.