### PR TITLE
Various database schema and access API changes for a speedup

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,14 +117,32 @@ from polytracker import PolyTrackerTrace
 trace = PolyTrackerTrace.load("polytracker.db")
 
 for event in trace:
+    # this prints every single event in the trace, in order
     print(event)
 
 for function in trace.functions:
+    # this returns a function object for every function observed
+    # (this is different than a function invocation, which we describe below)
     print(function.demangled_name)
 
 main_func = trace.get_function("main")
 for taint in main_func.taints().regions():
+    # this iterates over every taint touched by the main function aggregated across all invocations of main
     print(f"source={taint.source}, offset={taint.offset}, length={taint.length}, value={taint.value}")
+```
+Individual function invocations in the trace can also be enumerated:
+```python
+entrypoint = trace.entrypoint
+# entrypoint is a function invocation object associated with a single invocation of the entrypoint of the trace (main)
+print(f"Entrypoint is: {entrypoint!s}")
+for called_function in entrypoint.calls():
+    # called_function is another function invocation object
+    # associated with a function called from entrypoint
+    print(str(called_function))
+    for region in called_function.taints().regions():
+        # this will iterate over every tainted region operated on by called_function,
+        # including any functions called to from called_function
+        print(f"\t{region.value}")
 ```
 
 You can also run an instrumented binary directly from the REPL:

--- a/examples/Dockerfile-jq.demo
+++ b/examples/Dockerfile-jq.demo
@@ -14,8 +14,9 @@ WORKDIR /polytracker/the_klondike/jq
 
 RUN git submodule update --init
 RUN autoreconf -fi
-RUN ./configure --with-oniguruma=builtin --disable-valgrind --enable-all-static --prefix=/usr/local
-RUN make -j`nproc`
+RUN ./configure --with-oniguruma=builtin --disable-valgrind --enable-all-static --prefix=/usr/local \
+    CFLAGS="-DNDEBUG" LDFLAGS=-all-static
+RUN make LDFLAGS=-all-static -j`nproc`
 # && make check
 RUN get-bc -b jq && ${CC} --lower-bitcode -i jq.bc -o jq_track --libs m && mv jq_track /usr/local/bin/jq
 

--- a/polytracker/database.py
+++ b/polytracker/database.py
@@ -418,10 +418,23 @@ class DBTraceEvent(Base, TraceEvent):  # type: ignore
         return Taints(())
 
 
+class BlockEntries(Base):
+    __tablename__ = "block_entries"
+    event_id: int = Column(BigInteger,  ForeignKey("events.event_id"), primary_key=True)
+    entry_count: int = Column(BigInteger)
+
+    entry: "DBBasicBlockEntry" = relationship("DBBasicBlockEntry")
+
+
 class DBBasicBlockEntry(DBTraceEvent, BasicBlockEntry):  # type: ignore
     __mapper_args__ = {
         "polymorphic_identity": EventType.BLOCK_ENTER,  # type: ignore
     }
+
+    block_entries: BlockEntries = relationship("BlockEntries")
+
+    def entry_count(self) -> int:
+        return self.block_entries.entry_count
 
     @property
     def bb_index(self) -> int:

--- a/polytracker/database.py
+++ b/polytracker/database.py
@@ -425,7 +425,7 @@ class BlockEntries(Base):  # type: ignore
     event_id: int = Column(BigInteger,  ForeignKey("events.event_id"), primary_key=True)
     entry_count: int = Column(BigInteger)
 
-    entry: "DBBasicBlockEntry" = relationship("DBBasicBlockEntry")
+    entry: "DBBasicBlockEntry" = relationship("DBBasicBlockEntry", uselist=False)
 
 
 class DBBasicBlockEntry(DBTraceEvent, BasicBlockEntry):  # type: ignore
@@ -433,7 +433,7 @@ class DBBasicBlockEntry(DBTraceEvent, BasicBlockEntry):  # type: ignore
         "polymorphic_identity": EventType.BLOCK_ENTER,  # type: ignore
     }
 
-    block_entries: BlockEntries = relationship("BlockEntries")
+    block_entries: BlockEntries = relationship("BlockEntries", uselist=False)
 
     def entry_count(self) -> int:
         return self.block_entries.entry_count

--- a/polytracker/database.py
+++ b/polytracker/database.py
@@ -260,13 +260,12 @@ class DBBasicBlock(Base, BasicBlock):  # type: ignore
 
 class AccessedLabel(Base):  # type: ignore
     __tablename__ = "accessed_label"
+    access_id = Column(Integer, primary_key=True)
     event_id = Column(BigInteger, ForeignKey("events.event_id"))
     label = Column(Integer, ForeignKey("taint_forest.label"))
     access_type = Column(SmallInteger, SQLEnum(ByteAccessType))
 
     event = relationship("DBTaintAccess", uselist=False)
-
-    __table_args__ = (PrimaryKeyConstraint("event_id", "label", "access_type"),)
 
     def __lt__(self, other):
         return hasattr(other, "label") and self.label < other.label

--- a/polytracker/database.py
+++ b/polytracker/database.py
@@ -521,7 +521,7 @@ class DBFunctionInvocation(FunctionInvocation):
             except NoResultFound:
                 return iter(())
         # work backwards from our function_return, since returns have back-pointers to their associated function_entry:
-        ret = []
+        ret: List[DBFunctionInvocation] = []
         while event is not None:
             # find the last function return before event:
             try:
@@ -531,7 +531,8 @@ class DBFunctionInvocation(FunctionInvocation):
                     DBFunctionReturn.thread_id == thread_id
                 ).order_by(DBFunctionReturn.thread_event_id.desc()).limit(1).one()
                 event = func_return.function_entry
-                ret.append(DBFunctionInvocation(event, self.trace))
+                if event is not None:
+                    ret.append(DBFunctionInvocation(event, self.trace))
             except NoResultFound:
                 # there are no more function returns in this invocation
                 break

--- a/polytracker/database.py
+++ b/polytracker/database.py
@@ -57,7 +57,6 @@ class EventType(IntEnum):
     FUNC_ENTER = 0
     FUNC_RET = 1
     BLOCK_ENTER = 2
-    TAINT_ACCESS = 3
 
 
 class EdgeType(IntEnum):

--- a/polytracker/database.py
+++ b/polytracker/database.py
@@ -420,7 +420,7 @@ class DBTraceEvent(Base, TraceEvent):  # type: ignore
         )
 
 
-class BlockEntries(Base):
+class BlockEntries(Base):  # type: ignore
     __tablename__ = "block_entries"
     event_id: int = Column(BigInteger,  ForeignKey("events.event_id"), primary_key=True)
     entry_count: int = Column(BigInteger)

--- a/polytracker/database.py
+++ b/polytracker/database.py
@@ -1,4 +1,4 @@
-from enum import IntEnum, IntFlag
+from enum import IntEnum
 from pathlib import Path
 from typing import Iterable, Iterator, List, Optional, Set, Tuple, Union
 
@@ -32,6 +32,7 @@ from .tracing import (
     BasicBlock,
     BasicBlockEntry,
     BasicBlockType,
+    ByteAccessType,
     ByteOffset,
     Function,
     FunctionEntry,
@@ -44,13 +45,6 @@ from .tracing import (
 )
 
 Base = declarative_base()
-
-
-class ByteAccessType(IntFlag):
-    UNKNOWN_ACCESS = 0
-    INPUT_ACCESS = 1
-    CMP_ACCESS = 2
-    READ_ACCESS = 4
 
 
 class EventType(IntEnum):
@@ -102,16 +96,16 @@ class DBFunction(Base, Function):  # type: ignore
         "FunctionCFGEdge", primaryjoin="DBFunction.id==FunctionCFGEdge.src_id"
     )
     accessed_labels = relationship(
-        "AccessedLabel",
+        "DBTaintAccess",
         primaryjoin="and_(DBFunction.id==remote(DBBasicBlock.function_id), "
         "foreign(DBTraceEvent.block_gid)==DBBasicBlock.id, "
-        "foreign(AccessedLabel.event_id)==DBTraceEvent.event_id)",
+        "foreign(DBTaintAccess.event_id)==DBTraceEvent.event_id)",
         viewonly=True,
     )
 
     def taints(self) -> Taints:
         return DBTaintForestNode.taints(
-            (label.event.taint_forest_node for label in self.accessed_labels)
+            (label.taint_forest_node for label in self.accessed_labels)
         )
 
     @property
@@ -166,12 +160,6 @@ class DBBasicBlock(Base, BasicBlock):  # type: ignore
     events: Iterable["DBTraceEvent"] = relationship(
         "DBTraceEvent", order_by="asc(DBTraceEvent.event_id)"
     )
-    accessed_labels = relationship(
-        "AccessedLabel",
-        primaryjoin="and_(DBBasicBlock.id==remote(DBTraceEvent.block_gid), "
-        "foreign(AccessedLabel.event_id)==DBTraceEvent.event_id)",
-        viewonly=True,
-    )
     function = relationship("DBFunction", back_populates="basic_blocks")
 
     _children: Optional[Set[BasicBlock]] = None
@@ -180,6 +168,15 @@ class DBBasicBlock(Base, BasicBlock):  # type: ignore
     @property
     def index_in_function(self) -> int:  # type: ignore
         return self.id & 0x0000FFFF
+
+    @property
+    def accessed_labels(self) -> Iterable["DBTaintAccess"]:
+        return stream_results(
+            Session.object_session(self).query(DBTaintAccess).join(DBTraceEvent).filter(
+                DBTraceEvent.block_gid == self.id,
+                DBTaintAccess.event_id == DBTraceEvent.event_id
+            ).order_by(DBTaintAccess.access_id.asc()).all()
+        )
 
     def taints(self) -> Taints:
         return DBTaintForestNode.taints(
@@ -257,23 +254,23 @@ class DBBasicBlock(Base, BasicBlock):  # type: ignore
         return self._children  # type: ignore
 
 
-class AccessedLabel(Base):  # type: ignore
+class DBTaintAccess(Base, TaintAccess):  # type: ignore
     __tablename__ = "accessed_label"
     access_id = Column(Integer, primary_key=True)
     event_id = Column(BigInteger, ForeignKey("events.event_id"))
     label = Column(Integer, ForeignKey("taint_forest.label"))
     access_type = Column(SmallInteger, SQLEnum(ByteAccessType))
 
-    event = relationship("DBTaintAccess", uselist=False)
-
-    def __lt__(self, other):
-        return hasattr(other, "label") and self.label < other.label
+    event: "DBTraceEvent" = relationship("DBTraceEvent", back_populates="accessed_labels")
+    taint_forest_node: "DBTaintForestNode" = relationship(
+        "DBTaintForestNode", foreign_keys=[label], back_populates="accesses"
+    )
 
     def taints(self) -> Taints:
         return DBTaintForestNode.taints((self.taint_forest_node,))
 
 
-class DBTraceEvent(Base):  # type: ignore
+class DBTraceEvent(Base, TraceEvent):  # type: ignore
     __tablename__ = "events"
     event_id = Column(BigInteger)  # globally unique, globally sequential event counter
     thread_event_id = Column(
@@ -289,7 +286,7 @@ class DBTraceEvent(Base):  # type: ignore
 
     input = relationship("DBInput", back_populates="events")
     basic_block = relationship("DBBasicBlock", back_populates="events")
-    accessed_labels = relationship("AccessedLabel")
+    accessed_labels = relationship("DBTaintAccess")
 
     __mapper_args__ = {"polymorphic_on": "event_type"}
 
@@ -300,6 +297,9 @@ class DBTraceEvent(Base):  # type: ignore
     @property
     def uid(self) -> int:  # type: ignore
         return self.event_id
+
+    def touched_taint(self) -> bool:
+        return bool(self.accessed_labels)
 
     @property
     def function_entry(self) -> Optional[FunctionEntry]:
@@ -418,29 +418,6 @@ class DBTraceEvent(Base):  # type: ignore
         return Taints(())
 
 
-class DBTaintAccess(DBTraceEvent, TaintAccess):  # type: ignore
-    __mapper_args__ = {
-        "polymorphic_identity": EventType.TAINT_ACCESS,  # type: ignore
-    }
-
-    accessed_label = relationship(
-        "AccessedLabel",
-        primaryjoin="AccessedLabel.event_id==DBTaintAccess.event_id",
-        uselist=False,
-    )
-    taint_forest_node = relationship(
-        "DBTaintForestNode",
-        primaryjoin="and_(DBTaintAccess.event_id==remote(AccessedLabel.event_id), "
-        "AccessedLabel.label==foreign(DBTaintForestNode.label), "
-        "DBTaintForestNode.input_id==DBTaintAccess.input_id)",
-        viewonly=True,
-        uselist=False,
-    )
-
-    def taints(self) -> Taints:
-        return DBTaintForestNode.taints((self.taint_forest_node,))
-
-
 class DBBasicBlockEntry(DBTraceEvent, BasicBlockEntry):  # type: ignore
     __mapper_args__ = {
         "polymorphic_identity": EventType.BLOCK_ENTER,  # type: ignore
@@ -486,35 +463,17 @@ class DBBasicBlockEntry(DBTraceEvent, BasicBlockEntry):  # type: ignore
         except NoResultFound:
             return None
 
-    def next_taint_access(self) -> Optional[DBTaintAccess]:
-        if self.trace is None:
-            next_event = self.next_event
-            if isinstance(next_event, DBTaintAccess):
-                return next_event
-            else:
-                return None
-        try:
-            return self.trace.session.query(DBTaintAccess).filter(
-                DBTaintAccess.thread_id == self.thread_id,
-                DBTaintAccess.thread_event_id > self.thread_event_id,
-                DBTaintAccess.func_event_id == self.func_event_id
-            ).order_by(DBTaintAccess.thread_event_id.asc()).limit(1).one()
-        except NoResultFound:
-            return None
-
     def next_basic_block_in_function_that_touched_taint(self) -> Optional["BasicBlockEntry"]:
         if self.trace is None:
             return super().next_basic_block_in_function()
-        next_bb = self.next_basic_block_in_function()
-        if next_bb is None:
-            return None
-        next_taint_access = next_bb.next_taint_access()  # type: ignore
-        if next_taint_access is None:
-            return None
-        prev_event = next_taint_access.previous_control_flow_event
-        if isinstance(prev_event, BasicBlockEntry) and prev_event != self:
-            return prev_event
-        else:
+        try:
+            return self.trace.session.query(DBBasicBlockEntry).join(DBTaintAccess).filter(
+                DBBasicBlockEntry.thread_id == self.thread_id,
+                DBBasicBlockEntry.func_event_id == self.func_event_id,
+                DBBasicBlockEntry.thread_event_id > self.thread_event_id,
+                DBTraceEvent.event_id == DBBasicBlockEntry.event_id
+            ).order_by(DBBasicBlockEntry.thread_event_id.asc()).limit(1).one()
+        except NoResultFound:
             return None
 
 
@@ -561,9 +520,9 @@ class DBFunctionInvocation(FunctionInvocation):
 
     @property
     def touched_taint(self) -> bool:
-        query = self.trace.session.query(AccessedLabel).join(DBTraceEvent).filter(
+        query = self.trace.session.query(DBTaintAccess).join(DBTraceEvent).filter(
             DBTraceEvent.thread_id == self.function_entry.thread_id,
-            DBTraceEvent.thread_event_id > self.function_entry.thread_event_id
+            DBTraceEvent.thread_event_id >= self.function_entry.thread_event_id
         )
         ret = self.function_return
         if ret is not None:
@@ -574,14 +533,14 @@ class DBFunctionInvocation(FunctionInvocation):
             return False
 
     def taint_accesses(self) -> Iterator[DBTaintAccess]:
-        query = self.trace.session.query(DBTaintAccess).join(AccessedLabel).filter(
-            DBTaintAccess.thread_id == self.function_entry.thread_id,
-            DBTaintAccess.thread_event_id > self.function_entry.thread_event_id
+        query = self.trace.session.query(DBTaintAccess).join(DBTraceEvent).filter(
+            DBTraceEvent.thread_id == self.function_entry.thread_id,
+            DBTraceEvent.thread_event_id >= self.function_entry.thread_event_id,
         )
         ret = self.function_return
         if ret is not None:
-            query = query.filter(DBTaintAccess.thread_event_id < ret.thread_event_id)
-        return stream_results(query.order_by(DBTaintAccess.event_id.asc()))
+            query = query.filter(DBTraceEvent.thread_event_id < ret.thread_event_id)
+        return stream_results(query.order_by(DBTaintAccess.access_id.asc()))
 
     def taints(self) -> Taints:
         return DBTaintForestNode.taints(
@@ -820,7 +779,7 @@ class DBTaintForestNode(Base, TaintForestNode):  # type: ignore
     __table_args__ = (PrimaryKeyConstraint("input_id", "label"),)
 
     source = relationship("DBInput")
-    accessed_labels = relationship("AccessedLabel", foreign_keys=[label, input_id])
+    accesses = relationship("DBTaintAccess", foreign_keys=[label])
 
     def __hash__(self):
         return hash((self.input_id, self.label))

--- a/polytracker/database.py
+++ b/polytracker/database.py
@@ -166,6 +166,12 @@ class DBBasicBlock(Base, BasicBlock):  # type: ignore
     _predecessors: Optional[Set[BasicBlock]] = None
 
     @property
+    def entries(self) -> Iterator[BasicBlockEntry]:
+        return stream_results(Session.object_session(self).query(DBBasicBlockEntry).filter(
+            DBBasicBlockEntry.block_gid == self.id
+        ).order_by(DBBasicBlockEntry.event_id.asc()))
+
+    @property
     def index_in_function(self) -> int:  # type: ignore
         return self.id & 0x0000FFFF
 

--- a/polytracker/include/polytracker/logging.h
+++ b/polytracker/include/polytracker/logging.h
@@ -1,6 +1,7 @@
 #ifndef POLYTRACKER_LOGGING
 #define POLYTRACKER_LOGGING
 #include <stack>
+#include <unordered_map>
 
 #include "dfsan_types.h"
 #include "polytracker/output.h"
@@ -20,6 +21,7 @@ void logBBEntry(const char *fname, const function_id_t &findex,
 struct FunctionStackFrame {
   event_id_t func_event_id;
   function_id_t func_id;
+  std::unordered_map<block_id_t, block_entry_count_t> bb_entry_count;
 };
 
 using FunctionStack = std::stack<FunctionStackFrame>;

--- a/polytracker/include/polytracker/output.h
+++ b/polytracker/include/polytracker/output.h
@@ -17,12 +17,7 @@ enum class ByteAccessType : uint8_t {
   READ_ACCESS = 4
 };
 
-enum EventType : uint8_t {
-  FUNC_ENTER = 0,
-  FUNC_RET = 1,
-  BLOCK_ENTER = 2,
-  TAINT_ACCESS = 3
-};
+enum EventType : uint8_t { FUNC_ENTER = 0, FUNC_RET = 1, BLOCK_ENTER = 2 };
 
 enum EdgeType : uint8_t { FORWARD = 0, BACKWARD = 1 };
 
@@ -33,12 +28,8 @@ input_id_t storeNewInput(sqlite3 *output_db, const std::string &filename,
                          const int &trace_level);
 void sql_exec(sqlite3 *output_db, const char *cmd);
 void storeTaintAccess(sqlite3 *output_db, const dfsan_label &label,
-                      const event_id_t &event_id,
-                      const event_id_t &thread_event_id,
-                      const function_id_t &findex, const block_id_t &bindex,
-                      const input_id_t &input_id, const int &thread_id,
-                      const ByteAccessType &access_type,
-                      const event_id_t &func_event_id);
+                      const input_id_t &input_id,
+                      const ByteAccessType &access_type);
 
 void storeFunc(sqlite3 *output_db, const char *fname,
                const function_id_t &func_id);

--- a/polytracker/include/polytracker/output.h
+++ b/polytracker/include/polytracker/output.h
@@ -6,6 +6,7 @@
 typedef uint32_t input_id_t;
 typedef uint32_t function_id_t;
 typedef uint32_t block_id_t;
+typedef uint32_t block_entry_count_t;
 typedef uint64_t global_id_t;
 typedef uint64_t event_id_t;
 
@@ -46,6 +47,13 @@ void storeEvent(sqlite3 *output_db, const input_id_t &input_id,
                 const event_id_t &thread_event_id, EventType event_type,
                 const function_id_t &findex, const block_id_t &bindex,
                 const event_id_t &func_event_id);
+
+void storeBlockEntry(sqlite3 *output_db, const input_id_t &input_id,
+                     const int &thread_id, const event_id_t &event_id,
+                     const event_id_t &thread_event_id,
+                     const function_id_t &findex, const block_id_t &bindex,
+                     const event_id_t &func_event_id,
+                     const block_entry_count_t entry_count);
 
 void storeCanonicalMap(sqlite3 *output_db, const input_id_t &input_id,
                        const dfsan_label &label, const uint64_t &file_offset);

--- a/polytracker/include/polytracker/polytracker.h
+++ b/polytracker/include/polytracker/polytracker.h
@@ -6,7 +6,7 @@
 
 #define POLYTRACKER_VERSION_MAJOR 3
 #define POLYTRACKER_VERSION_MINOR 0
-#define POLYTRACKER_VERSION_REVISION 1
+#define POLYTRACKER_VERSION_REVISION 2
 
 // If there is a suffix, it should always start with a hypen, like "-alpha2.2".
 // If there is no suffix, set POLYTRACKER_VERSION_SUFFIX to an empty string.

--- a/polytracker/src/polytracker/logging.cpp
+++ b/polytracker/src/polytracker/logging.cpp
@@ -72,7 +72,7 @@ void logFunctionEntry(const char *fname, const function_id_t &func_id) {
                    this_event_id, EdgeType::FORWARD);
   storeEvent(output_db, input_id, thread_id, this_event_id, thread_event_id++,
              EventType::FUNC_ENTER, func_id, 0, this_event_id);
-  function_stack.push({this_event_id, func_id});
+  function_stack.push({this_event_id, func_id, {}});
   curr_func_index = func_id;
 }
 
@@ -123,9 +123,11 @@ void logBBEntry(const char *fname, const function_id_t &findex,
   // blocks
   storeBlock(output_db, findex, bindex, btype);
   last_bb_event_id = event_id++;
-  storeEvent(output_db, input_id, thread_id, last_bb_event_id,
-             thread_event_id++, EventType::BLOCK_ENTER, findex, bindex,
-             function_stack.empty() ? last_bb_event_id
-                                    : function_stack.top().func_event_id);
+  auto entryCount = function_stack.top().bb_entry_count[bindex]++;
+  storeBlockEntry(output_db, input_id, thread_id, last_bb_event_id,
+                  thread_event_id++, findex, bindex,
+                  function_stack.empty() ? last_bb_event_id
+                                         : function_stack.top().func_event_id,
+                  entryCount);
   curr_block_index = bindex;
 }

--- a/polytracker/src/polytracker/logging.cpp
+++ b/polytracker/src/polytracker/logging.cpp
@@ -20,6 +20,7 @@ thread_local function_id_t curr_func_index = -1;
 thread_local FunctionStack function_stack;
 thread_local int thread_id = -1;
 thread_local event_id_t thread_event_id = 0;
+thread_local event_id_t last_bb_event_id = 0;
 std::atomic<event_id_t> event_id = 0;
 std::atomic<size_t> last_thread_id{0};
 static bool is_init = false;
@@ -41,20 +42,12 @@ static void assignThreadID() {
 
 void logCompare(const dfsan_label &label, const function_id_t &findex,
                 const block_id_t &bindex) {
-  const auto this_event_id = event_id++;
-  storeTaintAccess(output_db, label, this_event_id, thread_event_id++, findex,
-                   bindex, input_id, thread_id, ByteAccessType::CMP_ACCESS,
-                   function_stack.empty() ? this_event_id
-                                          : function_stack.top().func_event_id);
+  storeTaintAccess(output_db, label, input_id, ByteAccessType::CMP_ACCESS);
 }
 
 void logOperation(const dfsan_label &label, const function_id_t &findex,
                   const block_id_t &bindex) {
-  const auto this_event_id = event_id++;
-  storeTaintAccess(output_db, label, event_id++, thread_event_id++, findex,
-                   bindex, input_id, thread_id, ByteAccessType::INPUT_ACCESS,
-                   function_stack.empty() ? this_event_id
-                                          : function_stack.top().func_event_id);
+  storeTaintAccess(output_db, label, input_id, ByteAccessType::INPUT_ACCESS);
 }
 
 void logFunctionEntry(const char *fname, const function_id_t &func_id) {
@@ -129,10 +122,10 @@ void logBBEntry(const char *fname, const function_id_t &findex,
   // NOTE (Carson) we could memoize this to prevent repeated calls for loop
   // blocks
   storeBlock(output_db, findex, bindex, btype);
-  const auto this_event_id = event_id++;
-  storeEvent(output_db, input_id, thread_id, this_event_id, thread_event_id++,
-             EventType::BLOCK_ENTER, findex, bindex,
-             function_stack.empty() ? this_event_id
+  last_bb_event_id = event_id++;
+  storeEvent(output_db, input_id, thread_id, last_bb_event_id,
+             thread_event_id++, EventType::BLOCK_ENTER, findex, bindex,
+             function_stack.empty() ? last_bb_event_id
                                     : function_stack.top().func_event_id);
   curr_block_index = bindex;
 }

--- a/polytracker/src/polytracker/output.cpp
+++ b/polytracker/src/polytracker/output.cpp
@@ -24,6 +24,8 @@ directory
 extern bool polytracker_trace;
 extern bool polytracker_save_input_file;
 
+extern thread_local event_id_t last_bb_event_id;
+
 // Could there be a race condition here?
 // TODO Check if input_table/taint_forest tables already filled
 extern std::unordered_map<std::string, std::unordered_map<dfsan_label, int>>
@@ -279,25 +281,19 @@ void storeEvent(sqlite3 *output_db, const input_id_t &input_id,
 }
 
 void storeTaintAccess(sqlite3 *output_db, const dfsan_label &label,
-                      const event_id_t &event_id,
-                      const event_id_t &thread_event_id,
-                      const function_id_t &findex, const block_id_t &bindex,
-                      const input_id_t &input_id, const int &thread_id,
-                      const ByteAccessType &access_type,
-                      const event_id_t &func_event_id) {
+                      const input_id_t &input_id,
+                      const ByteAccessType &access_type) {
   sqlite3_stmt *stmt;
   const char *insert =
       "INSERT INTO accessed_label(event_id, label, access_type, input_id)"
       "VALUES (?, ?, ?, ?);";
   sql_prep(output_db, insert, -1, &stmt, NULL);
-  sqlite3_bind_int64(stmt, 1, event_id);
+  sqlite3_bind_int64(stmt, 1, last_bb_event_id);
   sqlite3_bind_int64(stmt, 2, label);
   sqlite3_bind_int(stmt, 3, static_cast<int>(access_type));
   sqlite3_bind_int64(stmt, 4, input_id);
   sql_step(output_db, stmt);
   sqlite3_finalize(stmt);
-  storeEvent(output_db, input_id, thread_id, event_id, thread_event_id,
-             EventType::TAINT_ACCESS, findex, bindex, func_event_id);
 }
 
 void storeBlock(sqlite3 *output_db, const function_id_t &findex,

--- a/polytracker/src/polytracker/output.cpp
+++ b/polytracker/src/polytracker/output.cpp
@@ -280,6 +280,25 @@ void storeEvent(sqlite3 *output_db, const input_id_t &input_id,
   sqlite3_finalize(stmt);
 }
 
+void storeBlockEntry(sqlite3 *output_db, const input_id_t &input_id,
+                     const int &thread_id, const event_id_t &event_id,
+                     const event_id_t &thread_event_id,
+                     const function_id_t &findex, const block_id_t &bindex,
+                     const event_id_t &func_event_id,
+                     const block_entry_count_t entry_count) {
+  storeEvent(output_db, input_id, thread_id, event_id, thread_event_id,
+             EventType::BLOCK_ENTER, findex, bindex, func_event_id);
+  sqlite3_stmt *stmt;
+  const char *insert =
+      "INSERT OR IGNORE into block_entries(event_id, entry_count)"
+      "VALUES (?, ?)";
+  sql_prep(output_db, insert, -1, &stmt, NULL);
+  sqlite3_bind_int64(stmt, 1, event_id);
+  sqlite3_bind_int64(stmt, 2, entry_count);
+  sql_step(output_db, stmt);
+  sqlite3_finalize(stmt);
+}
+
 void storeTaintAccess(sqlite3 *output_db, const dfsan_label &label,
                       const input_id_t &input_id,
                       const ByteAccessType &access_type) {

--- a/polytracker/src/polytracker/tablegen.cpp
+++ b/polytracker/src/polytracker/tablegen.cpp
@@ -109,6 +109,15 @@ static constexpr const char *createEventsTable() {
          ") WITHOUT ROWID;";
 }
 
+static constexpr const char *createBlockEntryTable() {
+  return "CREATE TABLE IF NOT EXISTS block_entries ("
+         "event_id BIGINT," /* the event_id associated with the basic block
+                               entry */
+         "entry_count BIGINT,"
+         "PRIMARY KEY(event_id)"
+         ") WITHOUT ROWID;";
+}
+
 void createDBTables(sqlite3 *output_db) {
   std::string table_gen =
       std::string(createInputTable()) + std::string(createFuncTable()) +
@@ -119,6 +128,6 @@ void createDBTables(sqlite3 *output_db) {
       std::string(createPolytrackerTable()) +
       std::string(createCanonicalTable()) + std::string(createChunksTable()) +
       std::string(createCFGTable()) + std::string(createTaintForestTable()) +
-      std::string(createEventsTable());
+      std::string(createEventsTable()) + std::string(createBlockEntryTable());
   sql_exec(output_db, table_gen.c_str());
 }

--- a/polytracker/src/polytracker/tablegen.cpp
+++ b/polytracker/src/polytracker/tablegen.cpp
@@ -37,12 +37,12 @@ static constexpr const char *createBlockTable() {
 
 static constexpr const char *createTaintTable() {
   return "CREATE TABLE IF NOT EXISTS accessed_label ("
+         "  access_id INTEGER PRIMARY KEY,"
          "  event_id BIGINT,"
          "  label BIGINT,"
          "  access_type TINYINT,"
-         "  input_id BIGINT,"
-         "  PRIMARY KEY (event_id, label, access_type, input_id)"
-         ") WITHOUT ROWID;";
+         "  input_id BIGINT"
+         ");";
 }
 
 static constexpr const char *createPolytrackerTable() {

--- a/polytracker/src/polytracker/taint.cpp
+++ b/polytracker/src/polytracker/taint.cpp
@@ -174,13 +174,8 @@ void taintTargetRange(const char *mem, int offset, int len, int byte_start,
 
       // Log that we tainted data within this function from a taint source etc.
       // logOperation(new_label);
-      const auto this_event_id = event_id++;
-      storeTaintAccess(output_db, new_label, this_event_id, thread_event_id++,
-                       curr_func_index, curr_block_index, input_id, thread_id,
-                       ByteAccessType::READ_ACCESS,
-                       function_stack.empty()
-                           ? this_event_id
-                           : function_stack.top().func_event_id);
+      storeTaintAccess(output_db, new_label, input_id,
+                       ByteAccessType::READ_ACCESS);
       if (taint_offset_start == -1) {
         taint_offset_start = curr_byte_num;
         taint_offset_end = curr_byte_num;

--- a/polytracker/tracing.py
+++ b/polytracker/tracing.py
@@ -429,7 +429,7 @@ class FunctionEntry(ControlFlowEvent):
         return f"{self.__class__.__name__}({self.uid!r}, {self.function.name!r})"
 
 
-class TaintAccess(TraceEvent):
+class TaintAccess:
     def __repr__(self):
         return f"{self.__class__.__name__}({self.uid!r})"
 

--- a/polytracker/tracing.py
+++ b/polytracker/tracing.py
@@ -429,9 +429,34 @@ class FunctionEntry(ControlFlowEvent):
         return f"{self.__class__.__name__}({self.uid!r}, {self.function.name!r})"
 
 
+class ByteAccessType(IntFlag):
+    UNKNOWN_ACCESS = 0
+    INPUT_ACCESS = 1
+    CMP_ACCESS = 2
+    READ_ACCESS = 4
+
+
 class TaintAccess:
+    def __init__(self, access_id: int, event: TraceEvent, label: int, access_type: ByteAccessType):
+        self.access_id: int = access_id
+        self.event: TraceEvent = event
+        self.label: int = label
+        self.access_type: ByteAccessType = access_type
+
+    def taints(self) -> Taints:
+        raise NotImplementedError()
+
+    def __lt__(self, other):
+        return hasattr(other, "access_id") and self.access_id < other.access_id
+
+    def __hash__(self):
+        return self.access_id
+
+    def __eq__(self, other):
+        return isinstance(other, DBTaintAccess) and self.access_id == other.access_id
+
     def __repr__(self):
-        return f"{self.__class__.__name__}({self.uid!r})"
+        return f"{self.__class__.__name__}({self.access_id!r}, {self.event!r}, {self.label}, {self.access_type!r})"
 
 
 class BasicBlockEntry(ControlFlowEvent):

--- a/polytracker/tracing.py
+++ b/polytracker/tracing.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from argparse import ArgumentParser, Namespace, REMAINDER
 from collections import defaultdict
 from enum import IntFlag
+import itertools
 from os.path import commonpath
 from pathlib import Path
 import subprocess
@@ -315,6 +316,10 @@ class TraceEvent:
         raise NotImplementedError()
 
     @property
+    def touched_taint(self) -> bool:
+        return bool(self.taints())
+
+    @property
     @abstractmethod
     def previous_event(self) -> Optional["TraceEvent"]:
         raise NotImplementedError()
@@ -376,7 +381,7 @@ class FunctionEntry(ControlFlowEvent):
         super().__init__(uid=uid)
 
     @property
-    def caller(self) -> "BasicBlockEntry":
+    def caller(self) -> Optional["BasicBlockEntry"]:
         prev = self.previous_control_flow_event
         while prev is not None:
             if isinstance(prev, BasicBlockEntry):
@@ -386,7 +391,7 @@ class FunctionEntry(ControlFlowEvent):
                 if prev is None:
                     break
             prev = prev.previous_control_flow_event
-        raise ValueError(f"Unable to determine the caller for {self}")
+        return None
 
     @property
     def entrypoint(self) -> Optional["BasicBlockEntry"]:
@@ -396,6 +401,24 @@ class FunctionEntry(ControlFlowEvent):
                 raise ValueError(f"Unexpected basic block: {next_event}")
             return next_event
         return None
+
+    @property
+    def basic_block(self) -> BasicBlock:
+        """
+        Returns the entrypoint of this function
+        For the basic block that called into this function, use `self.caller`
+
+        """
+        if self.entrypoint is None:
+            raise ValueError(f"Unable to determine the function entrypoint for {self!r}")
+        return self.entrypoint.basic_block
+
+    @property
+    def function(self) -> Function:
+        """Returns the function that was entered"""
+        if self.entrypoint is None:
+            raise ValueError(f"Unable to determine the function entrypoint for {self!r}")
+        return self.entrypoint.function
 
     @property
     @abstractmethod
@@ -487,6 +510,90 @@ class FunctionReturn(ControlFlowEvent):
         return entry.basic_block.function
 
 
+class FunctionInvocation(TraceEvent):
+    def __init__(self, function_entry: FunctionEntry):
+        super().__init__(function_entry.uid)
+        self._function_entry: FunctionEntry = function_entry
+
+    @property
+    def basic_block(self) -> BasicBlock:
+        return self.function_entry.basic_block
+
+    @property
+    def function(self) -> Function:
+        return self.function_entry.function
+
+    @property
+    def previous_event(self) -> Optional["TraceEvent"]:
+        return self.function_entry.previous_event
+
+    @property
+    def next_event(self) -> Optional["TraceEvent"]:
+        return self.function_entry.next_event
+
+    @property
+    def next_global_event(self) -> Optional["TraceEvent"]:
+        return self.function_entry.next_global_event
+
+    @property
+    def previous_global_event(self) -> Optional["TraceEvent"]:
+        return self.function_entry.previous_global_event
+
+    @property
+    def function_return(self) -> Optional[FunctionReturn]:
+        return self.function_entry.function_return
+
+    @property
+    def function_entry(self) -> Optional["FunctionEntry"]:
+        return self._function_entry
+
+    def calls(self) -> Iterator["FunctionInvocation"]:
+        """Yields all of the functions called inside of this invocation, in order"""
+        next_event = self.function_entry.next_control_flow_event
+        return_event = self.function_return
+        while next_event is not None and next_event != return_event:
+            if isinstance(next_event, FunctionEntry):
+                yield FunctionInvocation(next_event)
+                next_event = next_event.function_return
+                if next_event is None:
+                    return
+            next_event = next_event.next_control_flow_event
+
+    def __eq__(self, other):
+        return isinstance(other, FunctionInvocation) and other.uid == self.uid
+
+    def __iter__(self) -> Iterator[ControlFlowEvent]:
+        """
+        Iterates all of the control flow events that took place during this function invocation, including all events
+        generated from calls to other functions from within this invocation
+
+        """
+        if self.function_return is None:
+            return
+        next_event = self.function_entry.next_control_flow_event
+        while next_event is not None and not next_event == self.function_return:
+            yield next_event
+            next_event = next_event.next_control_flow_event
+
+    def taints(self) -> Taints:
+        """Returns all taints operated on by this function or any functions called by this function"""
+        if not hasattr(self, "_taints"):
+            setattr(self, "_taints", Taints(itertools.chain(iter(event.taints()) for event in self)))  # type: ignore
+        return getattr(self, "_taints")
+
+    def __str__(self):
+        s = str(self.function)
+        caller = self.function_entry.caller
+        if caller is not None:
+            s = f"{s} called from {caller!s}"
+        return_event = self.function_return
+        if return_event is not None:
+            returning_to = return_event.returning_to
+            if returning_to is not None:
+                s = f"{s} returning to {returning_to!s}"
+        return s
+
+
 class ProgramTrace(ABC):
     _cfg: Optional[DiGraph[BasicBlock]] = None
     _func_cfg: Optional[DiGraph[Function]] = None
@@ -545,6 +652,33 @@ class ProgramTrace(ABC):
     @abstractmethod
     def taint_forest(self) -> TaintForest:
         raise NotImplementedError()
+
+    def function_trace(self) -> Iterator[FunctionEntry]:
+        return iter(event for event in self if isinstance(event, FunctionEntry))
+
+    def next_function_entry(self, after: Optional[FunctionEntry] = None) -> Optional[FunctionEntry]:
+        """Returns the next function entry, or None if none exists"""
+        if after is None:
+            try:
+                return next(iter(self.function_trace()))
+            except StopIteration:
+                return None
+        function_return = after.function_return
+        if function_return is None:
+            next_event = after.next_control_flow_event
+        else:
+            next_event = function_return.returning_to
+        while next_event is not None:
+            if isinstance(next_event, FunctionEntry):
+                return next_event
+        return None
+
+    @property
+    def entrypoint(self) -> Optional[FunctionInvocation]:
+        try:
+            return FunctionInvocation(next(iter(self.function_trace())))
+        except StopIteration:
+            return None
 
     @abstractmethod
     def __getitem__(self, uid: int) -> TraceEvent:

--- a/polytracker/tracing.py
+++ b/polytracker/tracing.py
@@ -536,7 +536,7 @@ class FunctionInvocation(TraceEvent):
         return self.function_entry.next_global_event
 
     @property
-    def previous_global_event(self) -> Optional["TraceEvent"]:
+    def previous_global_event(self) -> Optional[TraceEvent]:
         return self.function_entry.previous_global_event
 
     @property
@@ -544,7 +544,7 @@ class FunctionInvocation(TraceEvent):
         return self.function_entry.function_return
 
     @property
-    def function_entry(self) -> Optional["FunctionEntry"]:
+    def function_entry(self) -> FunctionEntry:
         return self._function_entry
 
     def calls(self) -> Iterator["FunctionInvocation"]:

--- a/polytracker/tracing.py
+++ b/polytracker/tracing.py
@@ -453,7 +453,7 @@ class TaintAccess:
         return self.access_id
 
     def __eq__(self, other):
-        return isinstance(other, DBTaintAccess) and self.access_id == other.access_id
+        return isinstance(other, TaintAccess) and self.access_id == other.access_id
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self.access_id!r}, {self.event!r}, {self.label}, {self.access_type!r})"

--- a/polytracker/tracing.py
+++ b/polytracker/tracing.py
@@ -265,6 +265,10 @@ class BasicBlock:
         function.basic_blocks.append(self)
 
     @abstractmethod
+    def entries(self) -> Iterator["BasicBlockEntry"]:
+        raise NotImplementedError()
+
+    @abstractmethod
     def taints(self) -> Taints:
         raise NotImplementedError()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,25 +1,32 @@
 import pytest
+from shutil import rmtree
+
+from .data import *
 
 
 def pytest_configure(config):
     config.addinivalue_line(
         "markers",
-        "program_trace: mark the C/C++ source file to be automatically compiled, instrumented, and instrumented for the test",
+        "program_trace: mark the C/C++ source file to be automatically compiled, instrumented, and run for the test",
     )
 
 
-def pytest_addoption(parser):
-    parser.addoption("--json", action="store", default=None, help="Path to JSON file")
-    parser.addoption(
-        "--forest", action="store", default=None, help="Path to forest file"
-    )
+@pytest.fixture(scope="session", autouse=True)
+def setup_targets():
+    """
+    Pytest fixture to init testing env (building tests)
+
+    This runs before any test is executed
+
+    """
+    if BUILD_DIR.exists():
+        rmtree(BUILD_DIR)
+    BUILD_DIR.mkdir()
+    if TEST_RESULTS_DIR.exists():
+        rmtree(TEST_RESULTS_DIR)
+    TEST_RESULTS_DIR.mkdir()
 
 
-@pytest.fixture
-def json_path(pytestconfig):
-    return pytestconfig.getoption("--json")
-
-
-@pytest.fixture
-def forest_path(pytestconfig):
-    return pytestconfig.getoption("--forest")
+pytest_plugins = [
+   "tests.tracing",
+]

--- a/tests/data.py
+++ b/tests/data.py
@@ -1,9 +1,7 @@
-import json
 import subprocess
 import sys
 from pathlib import Path
-from tempfile import NamedTemporaryFile
-from typing import Any, Dict, Optional, Union
+from typing import Optional, Union
 
 
 from polytracker.containerization import CAN_RUN_NATIVELY, DockerContainer
@@ -65,36 +63,7 @@ def generate_bad_path() -> Path:
 TESTS_DIR: Path = Path(__file__).parent
 TEST_DATA_DIR: Path = TESTS_DIR / "test_data"
 BAD_PATH: Path = generate_bad_path()
-BAD_FOREST_PATH: Path = TEST_DATA_DIR / "bad_forest.bin"
 CONFIG_DIR: Path = TESTS_DIR / "configs"
-GOOD_FOREST_PATH: Path = TEST_DATA_DIR / "polytracker_forest.bin"
-PROCESS_SET_PATH: Path = TEST_DATA_DIR / "polytracker_process_set.json"
 TEST_DATA_PATH: Path = TEST_DATA_DIR / "test_data.txt"
-BIN_DIR: Path = TEST_DATA_DIR / "bin"
-TEST_RESULTS_DIR = BIN_DIR / "test_results"
-BITCODE_DIR = TEST_DATA_DIR / "bitcode"
-
-
-__PROCESS_SET: Optional[Dict[str, Any]] = None
-
-
-def process_set() -> Dict[str, Any]:
-    global __PROCESS_SET
-    if __PROCESS_SET is None:
-        with open(PROCESS_SET_PATH, "r") as f:
-            __PROCESS_SET = json.load(f)
-    return __PROCESS_SET
-
-
-def canonical_mapping() -> Dict[int, int]:
-    pset: Dict[str, Any] = process_set()
-    if "canonical_mapping" not in pset:
-        raise ValueError(
-            f'Expected to find a "canonical_mapping" key in {PROCESS_SET_PATH!s}. '
-            "Perhaps it is using a newer JSON schema?"
-        )
-    elif len(pset["canonical_mapping"]) != 1:
-        raise ValueError(
-            f"{PROCESS_SET_PATH!s} was expected to have only one source, but found {pset.keys()!r}"
-        )
-    return dict(next(iter(pset["canonical_mapping"].values())))
+BUILD_DIR: Path = TEST_DATA_DIR / "build"
+TEST_RESULTS_DIR = TEST_DATA_DIR / "test_results"

--- a/tests/test_bb_splitting.c
+++ b/tests/test_bb_splitting.c
@@ -1,0 +1,29 @@
+__attribute__((noinline))
+void func2() {}
+__attribute__((noinline))
+void func3() {}
+__attribute__((noinline))
+void func4() {}
+__attribute__((noinline))
+void func5() {}
+
+__attribute__((noinline))
+void func1(volatile int* choice) {
+  func2();
+  if(*choice) {
+    for(int i=0; i<*choice; ++i) {
+      func3();
+    }
+  } else {
+    func4();
+  }
+  func5();
+}
+
+int main() {
+  volatile int choice = 0;
+  func1(&choice);
+  choice = 2;
+  func1(&choice);
+  return 0;
+}

--- a/tests/test_bb_splitting.py
+++ b/tests/test_bb_splitting.py
@@ -4,8 +4,6 @@ from typing import Dict, Set
 
 from polytracker import BasicBlock, BasicBlockEntry, FunctionReturn, ProgramTrace
 
-from .test_polytracker import program_trace
-
 
 @pytest.mark.program_trace("test_bb_splitting.c")
 def test_bb_splitting(program_trace: ProgramTrace):

--- a/tests/test_bb_splitting.py
+++ b/tests/test_bb_splitting.py
@@ -1,0 +1,39 @@
+from collections import defaultdict
+import pytest
+from typing import Dict, Set
+
+from polytracker import BasicBlock, BasicBlockEntry, FunctionReturn, ProgramTrace
+
+from .test_polytracker import program_trace
+
+
+@pytest.mark.program_trace("test_bb_splitting.c")
+def test_bb_splitting(program_trace: ProgramTrace):
+    """Ensure that every basic block has at most one funtion call or one conditional branch"""
+    entrypoint = program_trace.entrypoint
+    assert entrypoint is not None
+    assert entrypoint.function.name == "main"
+    jumps_to: Dict[BasicBlock, Set[BasicBlock]] = defaultdict(set)
+    must_not_be_conditional: Set[BasicBlock] = set()
+    indent = 0
+    for event in program_trace:
+        if not isinstance(event, BasicBlockEntry):
+            if isinstance(event, FunctionReturn):
+                assert indent >= 2
+                indent -= 2
+            continue
+        func = event.called_function
+        print(f"{'  ' * indent}{event}")
+        if func is not None:
+            # make sure the function returns to a basic block that is not conditional
+            assert func.function_return is not None
+            must_not_be_conditional.add(event.basic_block)
+            indent += 1
+            print(f"{'  ' * indent}{func}")
+            indent += 1
+        else:
+            if event.next_event is not None:
+                jumps_to[event.basic_block].add(event.next_event.basic_block)
+    for bb in must_not_be_conditional:
+        assert len(jumps_to[bb]) < 2, f"Basic block {bb} is the return site for a function, but it is conditional; it" \
+                                      f" jumps to {', '.join(map(str, jumps_to[bb]))}"

--- a/tests/test_data/.dockerignore
+++ b/tests/test_data/.dockerignore
@@ -1,0 +1,2 @@
+build
+test_results

--- a/tests/test_data/.gitignore
+++ b/tests/test_data/.gitignore
@@ -1,2 +1,2 @@
-bin/*
-bitcode/*
+build/*
+test_results/*

--- a/tests/test_grammars.py
+++ b/tests/test_grammars.py
@@ -1,0 +1,20 @@
+import pytest
+
+from polytracker import ProgramTrace
+from polytracker.grammars import extract
+
+from .test_polytracker import program_trace
+
+
+@pytest.mark.program_trace("test_fgetc.c", input="ABCDEFGH")
+def test_extract(program_trace: ProgramTrace):
+    grammar = extract([program_trace], simplify=False)
+    grammar.verify()
+    print(str(grammar))
+
+
+@pytest.mark.program_trace("test_fgetc.c", input="ABCDEFGH")
+def test_simplify(program_trace: ProgramTrace):
+    grammar = extract([program_trace], simplify=True)
+    grammar.verify()
+    print(str(grammar))

--- a/tests/test_grammars.py
+++ b/tests/test_grammars.py
@@ -3,8 +3,6 @@ import pytest
 from polytracker import ProgramTrace
 from polytracker.grammars import extract
 
-from .test_polytracker import program_trace
-
 
 @pytest.mark.program_trace("test_fgetc.c", input="ABCDEFGH")
 def test_extract(program_trace: ProgramTrace):

--- a/tests/test_polytracker.py
+++ b/tests/test_polytracker.py
@@ -323,7 +323,17 @@ def test_cxx_vector(program_trace: ProgramTrace):
 def test_fgetc(program_trace: ProgramTrace):
     for _ in program_trace:
         pass
-    assert program_trace.entrypoint.touched_taint
+    entrypoint = program_trace.entrypoint
+    assert entrypoint.touched_taint
+    tainted_regions = list(entrypoint.taints().regions())
+    assert len(tainted_regions) == 1
+    assert tainted_regions[0].value == b"ABCDEFGH"
+    called_by_main = list(entrypoint.calls())
+    assert len(called_by_main) == 8
+    for i, called in enumerate(called_by_main):
+        regions = list(called.taints().regions())
+        assert len(regions) == 1
+        assert regions[0].value == b"ABCDEFGH"[i:i+1]
 
 
 @pytest.mark.program_trace("test_simple_union.cpp", input="ABCDEFGH\n11235878\n")

--- a/tests/test_polytracker.py
+++ b/tests/test_polytracker.py
@@ -324,6 +324,7 @@ def test_fgetc(program_trace: ProgramTrace):
     for _ in program_trace:
         pass
     entrypoint = program_trace.entrypoint
+    assert entrypoint is not None
     assert entrypoint.touched_taint
     tainted_regions = list(entrypoint.taints().regions())
     assert len(tainted_regions) == 1

--- a/tests/test_polytracker.py
+++ b/tests/test_polytracker.py
@@ -205,6 +205,7 @@ def test_control_flow(program_trace: ProgramTrace):
     assert returns["func1"] == 1
     assert returns["func2"] == 6
     # check function invocation reconstruction:
+    assert program_trace.entrypoint is not None
     assert program_trace.entrypoint.function == main
     called_from_main = list(program_trace.entrypoint.calls())
     assert len(called_from_main) == 1

--- a/tests/test_polytracker.py
+++ b/tests/test_polytracker.py
@@ -1,8 +1,7 @@
 from collections import defaultdict
 import os
 import pytest
-from shutil import copyfile, rmtree
-from tempfile import NamedTemporaryFile
+from typing import Dict
 
 from tqdm import tqdm
 
@@ -10,152 +9,10 @@ from polytracker import (
     BasicBlockEntry,
     FunctionEntry,
     FunctionReturn,
-    PolyTrackerTrace,
     ProgramTrace,
 )
 
 from .data import *
-
-"""
-Pytest fixture to init testing env (building tests) 
-
-This runs before any test is executed
-"""
-
-
-@pytest.fixture(scope="session", autouse=True)
-def setup_targets():
-    if BUILD_DIR.exists():
-        rmtree(BUILD_DIR)
-    BUILD_DIR.mkdir()
-    if TEST_RESULTS_DIR.exists():
-        rmtree(TEST_RESULTS_DIR)
-    TEST_RESULTS_DIR.mkdir()
-
-
-def is_out_of_date(path: Path, *also_compare_to: Path) -> bool:
-    if not path.exists():
-        return True
-    elif CAN_RUN_NATIVELY:
-        return (
-            True  # For now, always rebuild binaries if we can run PolyTracker natively
-        )
-    # We need to run PolyTracker in a Docker container.
-    last_build_time = docker_container().last_build_time()
-    if last_build_time is None:
-        # The Docker container hasn't been built yet!
-        return True
-    last_path_modification = path.stat().st_mtime
-    if last_build_time >= last_path_modification:
-        # The Docker container was rebuilt since the last time `path` was modified
-        return True
-    for also_compare in also_compare_to:
-        other_time = also_compare.stat().st_mtime
-        if other_time >= last_path_modification:
-            # this dependency was modified after `path` was modified
-            return True
-    return False
-
-
-def polyclang_compile_target(target_name: str) -> int:
-    source_path = TESTS_DIR / target_name
-    bin_path = BUILD_DIR / f"{target_name}.bin"
-    if bin_path.exists() and not is_out_of_date(bin_path, source_path):
-        # we `rm -rf`'d the whole bin directory in setup_targets,
-        # so if the binary is already here, it means we built it already this run
-        return 0
-    if target_name.endswith(".cpp"):
-        build_cmd: str = "polybuild++"
-    else:
-        build_cmd = "polybuild"
-    compile_command = [
-        "/usr/bin/env",
-        build_cmd,
-        "--instrument-target",
-        "-g",
-        "-o",
-        to_native_path(bin_path),
-        to_native_path(source_path),
-    ]
-    return run_natively(*compile_command)
-
-
-# Returns the Polyprocess object
-def validate_execute_target(
-    target_name: str, config_path: Optional[Union[str, Path]], input_bytes: Optional[bytes] = None
-) -> ProgramTrace:
-    target_bin_path = BUILD_DIR / f"{target_name}.bin"
-    if CAN_RUN_NATIVELY:
-        assert target_bin_path.exists()
-    db_path = TEST_RESULTS_DIR / f"{target_name}.db"
-    if db_path.exists():
-        db_path.unlink()
-    if input_bytes is None:
-        input_path = to_native_path(TEST_DATA_PATH)
-        tmp_input_file = None
-    else:
-        tmp_input_file = NamedTemporaryFile(dir=str(TEST_DATA_DIR), delete=False)
-        tmp_input_file.write(input_bytes)
-        input_path = to_native_path(tmp_input_file.name)
-        tmp_input_file.close()
-    env = {
-        "POLYPATH": input_path,
-        "POLYDB": to_native_path(db_path),
-        "POLYTRACE": "1",
-        "POLYFUNC": "1"
-    }
-    tmp_config = Path(__file__).parent.parent / ".polytracker_config.json"
-    if config_path is not None:
-        copyfile(str(CONFIG_DIR / "new_range.json"), str(tmp_config))
-    try:
-        ret_val = run_natively(
-            env=env, *[to_native_path(target_bin_path), input_path]
-        )
-    finally:
-        if tmp_config.exists():
-            tmp_config.unlink()  # we can't use `missing_ok=True` here because that's only available in Python 3.9
-        if tmp_input_file is not None:
-            path = Path(tmp_input_file.name)
-            if path.exists():
-                path.unlink()
-    assert ret_val == 0
-    # Assert that the appropriate files were created
-    return PolyTrackerTrace.load(db_path)
-
-
-@pytest.fixture
-def program_trace(request):
-    marker = request.node.get_closest_marker("program_trace")
-    if marker is None:
-        raise ValueError(
-            """The program_trace fixture must be called with a target file name to compile. For example:
-
-    @pytest.mark.program_trace("foo.c")
-    def test_foo(program_trace: ProgramTrace):
-        \"\"\"foo.c will be compiled, instrumented, and run, and program_trace will be the resulting ProgramTrace\"\"\"
-        ...
-"""
-        )
-
-    target_name = marker.args[0]
-    if "config_path" in marker.kwargs:
-        config_path = marker.kwargs["config_path"]
-    else:
-        config_path = None
-    if "input" in marker.kwargs:
-        input_val = marker.kwargs["input"]
-        if isinstance(input_val, str):
-            input_bytes: Optional[bytes] = input_val.encode("utf-8")
-        elif isinstance(input_val, bytes):
-            input_bytes = input_val
-        else:
-            raise ValueError(f"Invalid input argument: {input_val!r}")
-    else:
-        input_bytes = None
-
-    assert polyclang_compile_target(target_name) == 0
-
-    return validate_execute_target(target_name, config_path=config_path, input_bytes=input_bytes)
 
 
 @pytest.mark.program_trace("test_mmap.c")

--- a/tests/test_polytracker.py
+++ b/tests/test_polytracker.py
@@ -207,15 +207,19 @@ def test_control_flow(program_trace: ProgramTrace):
     # check function invocation reconstruction:
     assert program_trace.entrypoint is not None
     assert program_trace.entrypoint.function == main
+    assert not program_trace.entrypoint.touched_taint
     called_from_main = list(program_trace.entrypoint.calls())
     assert len(called_from_main) == 1
     assert called_from_main[0].function == func1
+    assert not called_from_main[0].touched_taint
     called_from_func1 = list(called_from_main[0].calls())
     assert len(called_from_func1) == 1
     assert called_from_func1[0].function == func2
+    assert not called_from_func1[0].touched_taint
     called_from_func2 = list(called_from_func1[0].calls())
     assert len(called_from_func2) == 1
     assert called_from_func2[0].function == func2
+    assert not called_from_func2[0].touched_taint
     # our instrumentation doesn't currently emit a function return event for main, but that might change in the future
     # so for now just ignore main
 
@@ -317,8 +321,9 @@ def test_cxx_vector(program_trace: ProgramTrace):
 
 @pytest.mark.program_trace("test_fgetc.c", input="ABCDEFGH")
 def test_fgetc(program_trace: ProgramTrace):
-    for event in program_trace:
-        print(event)
+    for _ in program_trace:
+        pass
+    assert program_trace.entrypoint.touched_taint
 
 
 @pytest.mark.program_trace("test_simple_union.cpp", input="ABCDEFGH\n11235878\n")

--- a/tests/test_polytracker.py
+++ b/tests/test_polytracker.py
@@ -204,6 +204,17 @@ def test_control_flow(program_trace: ProgramTrace):
     assert entries["func2"] == 6
     assert returns["func1"] == 1
     assert returns["func2"] == 6
+    # check function invocation reconstruction:
+    assert program_trace.entrypoint.function == main
+    called_from_main = list(program_trace.entrypoint.calls())
+    assert len(called_from_main) == 1
+    assert called_from_main[0].function == func1
+    called_from_func1 = list(called_from_main[0].calls())
+    assert len(called_from_func1) == 1
+    assert called_from_func1[0].function == func2
+    called_from_func2 = list(called_from_func1[0].calls())
+    assert len(called_from_func2) == 1
+    assert called_from_func2[0].function == func2
     # our instrumentation doesn't currently emit a function return event for main, but that might change in the future
     # so for now just ignore main
 

--- a/tests/tracing.py
+++ b/tests/tracing.py
@@ -1,0 +1,132 @@
+import pytest
+from shutil import copyfile
+from tempfile import NamedTemporaryFile
+
+from polytracker import PolyTrackerTrace, ProgramTrace
+
+from .data import *
+
+
+def is_out_of_date(path: Path, *also_compare_to: Path) -> bool:
+    if not path.exists():
+        return True
+    elif CAN_RUN_NATIVELY:
+        return (
+            True  # For now, always rebuild binaries if we can run PolyTracker natively
+        )
+    # We need to run PolyTracker in a Docker container.
+    last_build_time = docker_container().last_build_time()
+    if last_build_time is None:
+        # The Docker container hasn't been built yet!
+        return True
+    last_path_modification = path.stat().st_mtime
+    if last_build_time >= last_path_modification:
+        # The Docker container was rebuilt since the last time `path` was modified
+        return True
+    for also_compare in also_compare_to:
+        other_time = also_compare.stat().st_mtime
+        if other_time >= last_path_modification:
+            # this dependency was modified after `path` was modified
+            return True
+    return False
+
+
+def polyclang_compile_target(target_name: str) -> int:
+    source_path = TESTS_DIR / target_name
+    bin_path = BUILD_DIR / f"{target_name}.bin"
+    if bin_path.exists() and not is_out_of_date(bin_path, source_path):
+        # we `rm -rf`'d the whole bin directory in setup_targets,
+        # so if the binary is already here, it means we built it already this run
+        return 0
+    if target_name.endswith(".cpp"):
+        build_cmd: str = "polybuild++"
+    else:
+        build_cmd = "polybuild"
+    compile_command = [
+        "/usr/bin/env",
+        build_cmd,
+        "--instrument-target",
+        "-g",
+        "-o",
+        to_native_path(bin_path),
+        to_native_path(source_path),
+    ]
+    return run_natively(*compile_command)
+
+
+# Returns the Polyprocess object
+def validate_execute_target(
+    target_name: str, config_path: Optional[Union[str, Path]], input_bytes: Optional[bytes] = None
+) -> ProgramTrace:
+    target_bin_path = BUILD_DIR / f"{target_name}.bin"
+    if CAN_RUN_NATIVELY:
+        assert target_bin_path.exists()
+    db_path = TEST_RESULTS_DIR / f"{target_name}.db"
+    if db_path.exists():
+        db_path.unlink()
+    if input_bytes is None:
+        input_path = to_native_path(TEST_DATA_PATH)
+        tmp_input_file = None
+    else:
+        tmp_input_file = NamedTemporaryFile(dir=str(TEST_DATA_DIR), delete=False)
+        tmp_input_file.write(input_bytes)
+        input_path = to_native_path(tmp_input_file.name)
+        tmp_input_file.close()
+    env = {
+        "POLYPATH": input_path,
+        "POLYDB": to_native_path(db_path),
+        "POLYTRACE": "1",
+        "POLYFUNC": "1"
+    }
+    tmp_config = Path(__file__).parent.parent / ".polytracker_config.json"
+    if config_path is not None:
+        copyfile(str(CONFIG_DIR / "new_range.json"), str(tmp_config))
+    try:
+        ret_val = run_natively(
+            env=env, *[to_native_path(target_bin_path), input_path]
+        )
+    finally:
+        if tmp_config.exists():
+            tmp_config.unlink()  # we can't use `missing_ok=True` here because that's only available in Python 3.9
+        if tmp_input_file is not None:
+            path = Path(tmp_input_file.name)
+            if path.exists():
+                path.unlink()
+    assert ret_val == 0
+    # Assert that the appropriate files were created
+    return PolyTrackerTrace.load(db_path)
+
+
+@pytest.fixture
+def program_trace(request):
+    marker = request.node.get_closest_marker("program_trace")
+    if marker is None:
+        raise ValueError(
+            """The program_trace fixture must be called with a target file name to compile. For example:
+
+    @pytest.mark.program_trace("foo.c")
+    def test_foo(program_trace: ProgramTrace):
+        \"\"\"foo.c will be compiled, instrumented, and run, and program_trace will be the resulting ProgramTrace\"\"\"
+        ...
+"""
+        )
+
+    target_name = marker.args[0]
+    if "config_path" in marker.kwargs:
+        config_path = marker.kwargs["config_path"]
+    else:
+        config_path = None
+    if "input" in marker.kwargs:
+        input_val = marker.kwargs["input"]
+        if isinstance(input_val, str):
+            input_bytes: Optional[bytes] = input_val.encode("utf-8")
+        elif isinstance(input_val, bytes):
+            input_bytes = input_val
+        else:
+            raise ValueError(f"Invalid input argument: {input_val!r}")
+    else:
+        input_bytes = None
+
+    assert polyclang_compile_target(target_name) == 0
+
+    return validate_execute_target(target_name, config_path=config_path, input_bytes=input_bytes)


### PR DESCRIPTION
`TaintAccess`es are no longer events and each have their own sequential global UID. Basic block entry counts are calculated at runtime rather than in post-processing.