### PR TITLE
Carson/update docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM trailofbits/polytracker-llvm:a783d2672b3062d3246ef1a9dd24661838f55fa1
+FROM trailofbits/polytracker-llvm:latest
 
 MAINTAINER Evan Sultanik <evan.sultanik@trailofbits.com>
 MAINTAINER Carson Harmon <carson.harmon@trailofbits.com>

--- a/polytracker/custom_abi/dfsan_abilist.txt
+++ b/polytracker/custom_abi/dfsan_abilist.txt
@@ -50,6 +50,8 @@ fun:__polytracker_size=uninstrumented
 fun:__polytracker_size=discard
 fun:__polytracker_start=uninstrumented
 fun:__polytracker_start=discard
+fun:__polytracker_log_call_exit=uninstrumented
+fun:__polytracker_log_call_exit=discard
 fun:__dfsan_update_label_count=uninstrumented
 fun:__dfsan_update_label_count=discard
 


### PR DESCRIPTION
Updates to pull polytracker-llvm latest + updates an ignore list to make sure we're not using an unintended layer of indirection. 