### PR TITLE
Carson/store blocks

### DIFF
--- a/polytracker/include/polytracker/polytracker_pass.h
+++ b/polytracker/include/polytracker/polytracker_pass.h
@@ -57,6 +57,7 @@ struct PolytrackerPass : public llvm::ModulePass,
   llvm::FunctionCallee preserve_map;
 
   std::unordered_map<llvm::BasicBlock *, uint64_t> block_global_map;
+  std::unordered_map<uint64_t, uint8_t> block_type_map;
   std::unordered_map<std::string, func_index_t> func_index_map;
   const int shadow_width = 32;
   llvm::IntegerType *shadow_type;

--- a/polytracker/src/passes/polytracker_pass.cpp
+++ b/polytracker/src/passes/polytracker_pass.cpp
@@ -236,8 +236,6 @@ bool PolytrackerPass::analyzeBlock(llvm::Function *func,
   auto res = new_IRB.CreateCall(bb_entry_log, {FuncIndex, BBIndex, BBType});
   uint64_t gid = static_cast<uint64_t>(findex) << 32 | bb_index;
   block_global_map[curr_bb] = gid;
-  std::cout << "Loading fid: " << findex << " bid " << bb_index
-            << " gid: " << gid << std::endl;
   block_type_map[gid] = bb_type;
   return true;
 }
@@ -478,7 +476,7 @@ create_globals(llvm::Module &mod,
 
 static llvm::GlobalVariable *
 create_block_map(llvm::Module &mod,
-                 std::unordered_map<uint64_t, uint8_t> blocks) {
+                 std::unordered_map<uint64_t, uint8_t> &blocks) {
   llvm::LLVMContext &context = mod.getContext();
   auto int64_type = llvm::IntegerType::getInt64Ty(context);
   auto int8_type = llvm::IntegerType::getInt8Ty(context);

--- a/polytracker/src/passes/polytracker_pass.cpp
+++ b/polytracker/src/passes/polytracker_pass.cpp
@@ -182,14 +182,13 @@ bool PolytrackerPass::analyzeBlock(llvm::Function *func,
   bool wasSplit = std::find(split_bbs.cbegin(), split_bbs.cend(), curr_bb) !=
                   split_bbs.cend();
   // bool wasSplit = false;
+  auto bb_type = static_cast<uint8_t>(
+      polytracker::getType(curr_bb, DT) |
+      (wasSplit ? polytracker::BasicBlockType::FUNCTION_RETURN
+                : polytracker::BasicBlockType::UNKNOWN));
 
   llvm::Value *BBType = llvm::ConstantInt::get(
-      llvm::IntegerType::getInt8Ty(context),
-      static_cast<uint8_t>(polytracker::getType(curr_bb, DT) |
-                           (wasSplit
-                                ? polytracker::BasicBlockType::FUNCTION_RETURN
-                                : polytracker::BasicBlockType::UNKNOWN)),
-      false);
+      llvm::IntegerType::getInt8Ty(context), bb_type, false);
 
   // llvm::Value *BBType =
   // llvm::ConstantInt::get(llvm::IntegerType::getInt8Ty(context),
@@ -237,6 +236,9 @@ bool PolytrackerPass::analyzeBlock(llvm::Function *func,
   auto res = new_IRB.CreateCall(bb_entry_log, {FuncIndex, BBIndex, BBType});
   uint64_t gid = static_cast<uint64_t>(findex) << 32 | bb_index;
   block_global_map[curr_bb] = gid;
+  std::cout << "Loading fid: " << findex << " bid " << bb_index
+            << " gid: " << gid << std::endl;
+  block_type_map[gid] = bb_type;
   return true;
 }
 
@@ -453,19 +455,16 @@ static llvm::GlobalVariable *
 create_globals(llvm::Module &mod,
                std::unordered_map<std::string, uint32_t> &func_index_map) {
   llvm::LLVMContext &context = mod.getContext();
-  auto int64_type = llvm::IntegerType::getInt64Ty(mod.getContext());
-  auto int32_type = llvm::IntegerType::getInt32Ty(mod.getContext());
-  auto int8_ty = llvm::IntegerType::getInt8Ty(context);
-  auto str_type = llvm::IntegerType::getInt8PtrTy(mod.getContext());
-  llvm::StructType *func_struct = llvm::StructType::create(
-      mod.getContext(), {str_type, int32_type}, "func_struct");
+  auto int32_type = llvm::IntegerType::getInt32Ty(context);
+  auto str_type = llvm::IntegerType::getInt8PtrTy(context);
+  llvm::StructType *func_struct =
+      llvm::StructType::create(context, {str_type, int32_type}, "func_struct");
   std::vector<llvm::Constant *> const_structs;
   for (auto pair : func_index_map) {
     auto key = pair.first;
     auto val = pair.second;
     auto key_const = create_str(mod, key);
-    auto val_const = llvm::ConstantInt::get(
-        llvm::IntegerType::getInt32Ty(mod.getContext()), val);
+    auto val_const = llvm::ConstantInt::get(int32_type, val);
     auto struct_const =
         llvm::ConstantStruct::get(func_struct, {key_const, val_const});
     const_structs.push_back(struct_const);
@@ -474,6 +473,30 @@ create_globals(llvm::Module &mod,
   auto global_structs = new llvm::GlobalVariable(
       mod, arr_type, true, llvm::GlobalVariable::InternalLinkage,
       llvm::ConstantArray::get(arr_type, const_structs), "func_index_map");
+  return global_structs;
+}
+
+static llvm::GlobalVariable *
+create_block_map(llvm::Module &mod,
+                 std::unordered_map<uint64_t, uint8_t> blocks) {
+  llvm::LLVMContext &context = mod.getContext();
+  auto int64_type = llvm::IntegerType::getInt64Ty(context);
+  auto int8_type = llvm::IntegerType::getInt8Ty(context);
+  llvm::StructType *block_struct = llvm::StructType::create(
+      context, {int64_type, int8_type}, "block_struct");
+  std::vector<llvm::Constant *> const_structs;
+  for (auto item : blocks) {
+    auto block_id_const = llvm::ConstantInt::get(int64_type, item.first);
+    auto block_type_const = llvm::ConstantInt::get(int8_type, item.second);
+    auto block_struct_const = llvm::ConstantStruct::get(
+        block_struct, {block_id_const, block_type_const});
+    const_structs.push_back(block_struct_const);
+  }
+  auto arr_type = llvm::ArrayType::get(block_struct, const_structs.size());
+  auto global_structs = new llvm::GlobalVariable(
+      mod, arr_type, true, llvm::GlobalVariable::InternalLinkage,
+      llvm::ConstantArray::get(arr_type, const_structs), "block_index_map");
+
   return global_structs;
 }
 
@@ -568,15 +591,21 @@ bool PolytrackerPass::runOnModule(llvm::Module &mod) {
   }
   std::cerr << std::endl;
   llvm::GlobalVariable *global = create_globals(mod, func_index_map);
+  llvm::GlobalVariable *block_map = create_block_map(mod, block_type_map);
   for (auto &func : mod) {
     if (func.hasName() && func.getName().str() == "main") {
       llvm::BasicBlock &bb = func.getEntryBlock();
       llvm::Instruction &insert_point = *(bb.getFirstInsertionPt());
       llvm::IRBuilder<> IRB(&insert_point);
+
       llvm::Value *save_map = IRB.CreateCall(
           preserve_map,
           IRB.CreateBitOrPointerCast(
               global, llvm::Type::getInt8PtrTy(mod.getContext())));
+      llvm::Value *save_block_map = IRB.CreateCall(
+          preserve_map,
+          IRB.CreateBitOrPointerCast(
+              block_map, llvm::Type::getInt8PtrTy(mod.getContext())));
     }
   }
   // auto it = global->getIterator();

--- a/polytracker/src/polytracker/logging.cpp
+++ b/polytracker/src/polytracker/logging.cpp
@@ -107,10 +107,11 @@ void logFunctionExit(const function_id_t index, const int stack_loc) {
 void logBBEntry(const function_id_t findex, const block_id_t bindex,
                 const uint8_t btype) {
   assignThreadID();
-  // NOTE (Carson) we could cache this to prevent repeated calls for loop
-  // blocks
-  storeBlock(output_db, findex, bindex, btype);
   last_bb_event_id = event_id++;
+  uint64_t gid = static_cast<uint64_t>(findex) << 32 | bindex;
+  std::cout << "RT hit fid: " << findex << " bid: " << bindex << " gid: " << gid
+            << std::endl;
+
   auto entryCount = function_stack.back().bb_entry_count[bindex]++;
   storeBlockEntry(output_db, input_id, thread_id, last_bb_event_id,
                   thread_event_id++, findex, bindex,

--- a/polytracker/src/polytracker/logging.cpp
+++ b/polytracker/src/polytracker/logging.cpp
@@ -108,9 +108,10 @@ void logBBEntry(const function_id_t findex, const block_id_t bindex,
                 const uint8_t btype) {
   assignThreadID();
   last_bb_event_id = event_id++;
-  uint64_t gid = static_cast<uint64_t>(findex) << 32 | bindex;
-  std::cout << "RT hit fid: " << findex << " bid: " << bindex << " gid: " << gid
-            << std::endl;
+  // uint64_t gid = static_cast<uint64_t>(findex) << 32 | bindex;
+  // std::cout << "RT hit fid: " << findex << " bid: " << bindex << " gid: " <<
+  // gid
+  //          << std::endl;
 
   auto entryCount = function_stack.back().bb_entry_count[bindex]++;
   storeBlockEntry(output_db, input_id, thread_id, last_bb_event_id,

--- a/polytracker/src/polytracker/output.cpp
+++ b/polytracker/src/polytracker/output.cpp
@@ -441,7 +441,8 @@ llvm::Module *extract_bc(llvm::LLVMContext &context, const char *data,
 
 bool extract_operand(llvm::ConstantStruct *const_struct, int operand_id,
                      uint64_t &out) {
-  auto val = llvm::dyn_cast<llvm::ConstantInt>(const_struct->getOperand(1));
+  auto val =
+      llvm::dyn_cast<llvm::ConstantInt>(const_struct->getOperand(operand_id));
   if (!val) {
     std::cerr << "Error! Unable to cast to constant struct" << std::endl;
     return false;
@@ -588,8 +589,6 @@ void storeBlob(sqlite3 *output_db, void *blob, int size) {
     uint64_t func_id = item.first >> 32;
     // Higher 32 bits (4 bytes) are func_id, so remove them
     uint64_t block_id = item.first & 0x00000000FFFFFFFF;
-    std::cout << "Storing fid: " << func_id << " bid: " << block_id
-              << " gid: " << item.first << std::endl;
     storeBlock(output_db, func_id, block_id, item.second);
   }
   /*

--- a/polytracker/src/polytracker/output.cpp
+++ b/polytracker/src/polytracker/output.cpp
@@ -439,6 +439,78 @@ llvm::Module *extract_bc(llvm::LLVMContext &context, const char *data,
   return mod;
 }
 
+bool extract_operand(llvm::ConstantStruct *const_struct, int operand_id,
+                     uint64_t &out) {
+  auto val = llvm::dyn_cast<llvm::ConstantInt>(const_struct->getOperand(1));
+  if (!val) {
+    std::cerr << "Error! Unable to cast to constant struct" << std::endl;
+    return false;
+  }
+  out = val->getZExtValue();
+  return true;
+}
+
+bool extract_operand(llvm::ConstantStruct *const_struct, int operand_id,
+                     std::string &out) {
+  // Get the first operand, gep --> str ptr --> str bytes
+  auto const_op = const_struct->getOperand(operand_id);
+  auto str_ptr = const_op->getOperand(0);
+  llvm::Constant *const_ptr = llvm::dyn_cast<llvm::Constant>(str_ptr);
+  if (!const_ptr) {
+    std::cerr << "Error! GEP Operand is not a constant" << std::endl;
+    exit(1);
+  }
+  // Deref the string pointer
+  auto str_bytes = const_ptr->getOperand(0);
+  // Cast the string to the constant data array
+  if (auto arr_ty = llvm::dyn_cast<llvm::ConstantDataArray>(str_bytes)) {
+    out = arr_ty->getRawDataValues().str();
+  } else {
+    std::cerr << "Error! Expected string to be constant data array"
+              << std::endl;
+    exit(1);
+  }
+  return true;
+}
+
+template <typename Key, typename Val>
+static std::unordered_map<Key, Val>
+extract_dict(llvm::Module *mod, const std::string &global_name) {
+  auto global = mod->getNamedGlobal(global_name);
+  if (!global) {
+    std::cerr << "Error! Unable to find named global: " << global_name
+              << std::endl;
+    exit(1);
+  }
+
+  std::unordered_map<Key, Val> ret_map;
+  auto init = global->getInitializer();
+  for (int i = 0; i < init->getNumOperands(); i++) {
+    Key dict_key;
+    Val dict_val;
+
+    // Peel the boilerplate.
+    llvm::Value *item = init->getOperand(i);
+    if (auto const_struct = llvm::dyn_cast<llvm::ConstantStruct>(item)) {
+      if (!extract_operand(const_struct, 0, dict_key)) {
+        std::cerr << "Extracting operand 0 failed!" << std::endl;
+        exit(1);
+      }
+      if (!extract_operand(const_struct, 1, dict_val)) {
+        std::cerr << "Extracting operand 1 failed!" << std::endl;
+        exit(1);
+      }
+      ret_map[dict_key] = dict_val;
+    } else {
+      std::cerr << "Error! Unable to cast to constant struct" << std::endl;
+      exit(1);
+    }
+    // Store
+    // storeFunc(output_db, func_name.c_str(), func_val);
+  }
+  return ret_map;
+}
+/*
 static bool store_dictionary(llvm::Module *mod, const std::string &global_name,
                              sqlite3 *output_db) {
   auto global = mod->getNamedGlobal(global_name);
@@ -488,7 +560,13 @@ static bool store_dictionary(llvm::Module *mod, const std::string &global_name,
   }
   return true;
 }
+*/
+/*
+static bool store_block_map(llvm::Module*, const char* block_map_name, sqlite3*
+output_db) {
 
+}
+*/
 void storeBlob(sqlite3 *output_db, void *blob, int size) {
   sqlite3_bind_blob(blob_insert_stmt, 1, blob, size, SQLITE_STATIC);
   sql_step(output_db, blob_insert_stmt);
@@ -499,10 +577,31 @@ void storeBlob(sqlite3 *output_db, void *blob, int size) {
     std::cerr << "Storing blob: unable to extract bc" << std::endl;
     exit(1);
   }
+  std::unordered_map<std::string, uint64_t> func_map =
+      extract_dict<std::string, uint64_t>(mod, "func_index_map");
+  for (auto item : func_map) {
+    storeFunc(output_db, item.first.c_str(), item.second);
+  }
+  std::unordered_map<uint64_t, uint64_t> block_map =
+      extract_dict<uint64_t, uint64_t>(mod, "block_index_map");
+  for (auto item : block_map) {
+    uint64_t func_id = item.first >> 32;
+    // Higher 32 bits (4 bytes) are func_id, so remove them
+    uint64_t block_id = item.first & 0x00000000FFFFFFFF;
+    std::cout << "Storing fid: " << func_id << " bid: " << block_id
+              << " gid: " << item.first << std::endl;
+    storeBlock(output_db, func_id, block_id, item.second);
+  }
+  /*
   if (!store_dictionary(mod, "func_index_map", output_db)) {
     std::cerr << "Storing function mapping failed" << std::endl;
     exit(1);
   }
+  if (!store_block_map(mod, "block_index_map", output_db)) {
+    std::cerr << "Storing block map failed" << std::endl;
+    exit(1);
+  }
+  */
 }
 
 void storeBlockEntry(sqlite3 *output_db, const input_id_t &input_id,


### PR DESCRIPTION
This PR removes calling storeBlock on the hot path the same way we removed storeFunc, but storing block information into the program and then reading it all at once. 

It also changes the code into C++ templates to be reused for other artifacts we might want to store into the program. 



