### PR TITLE
Instrumenting switch cases to detect taint that influence control flow

### DIFF
--- a/polytracker/include/polytracker/polytracker_pass.h
+++ b/polytracker/include/polytracker/polytracker_pass.h
@@ -38,6 +38,7 @@ struct PolytrackerPass : public llvm::ModulePass,
   void visitCallInst(llvm::CallInst &ci);
   void visitReturnInst(llvm::ReturnInst &RI);
   void visitBranchInst(llvm::BranchInst &BI);
+  void visitSwitchInst(llvm::SwitchInst &SI);
   const std::pair<llvm::Value *, llvm::Value *>
   getIndicies(llvm::Instruction *);
 

--- a/polytracker/src/passes/polytracker_pass.cpp
+++ b/polytracker/src/passes/polytracker_pass.cpp
@@ -138,7 +138,6 @@ void PolytrackerPass::visitBranchInst(llvm::BranchInst &BI) {
 void PolytrackerPass::visitSwitchInst(llvm::SwitchInst &SI) {
   // TODO (hbrodin): Is a guard needed? E.g. op_check as in visitBranchInst?
   llvm::IRBuilder<> IRB(&SI);
-  llvm::LLVMContext &context = mod->getContext();
   llvm::Value *int_val = IRB.CreateSExtOrTrunc(SI.getCondition(), shadow_type);
   CallInst *Call = IRB.CreateCall(conditional_branch_log, {int_val});
 }
@@ -597,12 +596,11 @@ bool PolytrackerPass::runOnModule(llvm::Module &mod) {
         }
       }
       for (auto &bb : func) {
-        for (auto &inst : bb) {
-          if (auto *BI = llvm::dyn_cast<llvm::BranchInst>(&inst)) {
-            visitBranchInst(*BI);
-          } else if (auto *SI = llvm::dyn_cast<llvm::SwitchInst>(&inst)) {
-            visitSwitch(*SI);
-          }
+        auto inst = bb.getTerminator();
+        if (auto *BI = llvm::dyn_cast<llvm::BranchInst>(inst)) {
+          visitBranchInst(*BI);
+        } else if (auto *SI = llvm::dyn_cast<llvm::SwitchInst>(inst)) {
+          visitSwitch(*SI);
         }
       }
     }

--- a/polytracker/src/passes/polytracker_pass.cpp
+++ b/polytracker/src/passes/polytracker_pass.cpp
@@ -121,8 +121,9 @@ void PolytrackerPass::visitBranchInst(llvm::BranchInst &BI) {
   if (BI.isUnconditional()) {
     return;
   } else if (auto condition = BI.getCondition()) {
-    // TODO (hbrodin): Is this to ensure that the size of the argument is at most sizeof(shadow_type)??
-    // To be able to pass it as first ar to conditional_branch_log
+    // TODO (hbrodin): Is this to ensure that the size of the argument is at
+    // most sizeof(shadow_type)?? To be able to pass it as first arg to
+    // conditional_branch_log
     if (!op_check(condition)) {
       llvm::IRBuilder<> IRB(&BI);
       llvm::LLVMContext &context = mod->getContext();

--- a/polytracker/src/taint_sources/write_taints.cpp
+++ b/polytracker/src/taint_sources/write_taints.cpp
@@ -54,7 +54,7 @@ EXT_C_FUNC size_t __dfsw_fwrite(void *buf, size_t size, size_t count,
   if (auto &input_id = get_fd_input_map()[fd]) {
     storeTaintedOutputChunk(output_db, input_id, current_offset,
                             current_offset + write_count);
-    for (auto i = 0; i < write_count; i++) {
+    for (auto i = 0; i < write_count * size; i++) {
       auto taint_label = dfsan_read_label((char *)buf + i, sizeof(char));
       storeTaintedOutput(output_db, input_id, current_offset, taint_label);
       current_offset += 1;


### PR DESCRIPTION
Previously, only branch instructions was only considered to affect control flow. This PR instruments switch instructions as well. Switch instructions do also affect control flow.