### PR TITLE
LabelDeq correction and performance improvement

### DIFF
--- a/polytracker/src/taintdag/test/labeldeq.cpp
+++ b/polytracker/src/taintdag/test/labeldeq.cpp
@@ -6,6 +6,16 @@
 
 using namespace taintdag;
 
+
+TEST_CASE("LabelDeq basic properties") {
+  utils::LabelDeq<15> l;
+  REQUIRE(l.empty());
+  l.push_back(1);
+  REQUIRE(!l.empty());
+  REQUIRE(l.pop_front() == 1);
+  REQUIRE(l.empty());
+}
+
 TEST_CASE("LabelDeq behaves equal to std list (push_back/pop_front)") {
   auto s = test::init_rand_seed();
   INFO("Init rand with seed" << s)


### PR DESCRIPTION
There was a bug in LabelDeq that caused it to always choose the deque-path,
never the stack based path. It worked correctly, only slightly slower.
This commit fixes that and rewrites the impl to not use a variant, also
aiming to increase performance since this is one of the most common operations
called via TaintDAG::affects_control_flow.

In my testing I have seen significant speedup when applying this.