### PR TITLE
Unify example images

### DIFF
--- a/build_in_docker/file_cavity_detection.py
+++ b/build_in_docker/file_cavity_detection.py
@@ -168,7 +168,7 @@ class MuTool(Tool):
         super().__init__(timeout)
 
     def image_instrumented(self):
-        return "mupdf"
+        return "trailofbits/polytracker-demo-mupdf"
 
     def input_extension(self) -> str:
         return ".pdf"
@@ -193,7 +193,7 @@ class OpenJPEG(Tool):
         super().__init__(timeout)
 
     def image_instrumented(self):
-        return "openjpg"
+        return "trailofbits/polytracker-demo-openjpeg"
 
     def input_extension(self) -> str:
         return ".jp2"
@@ -218,7 +218,7 @@ class LibJPEG(Tool):
         super().__init__(timeout)
 
     def image_instrumented(self):
-        return "libjpeg"
+        return "trailofbits/polytracker-demo-libjpeg"
 
     def input_extension(self) -> str:
         return ".jpg"

--- a/build_in_docker/file_cavity_detection.py
+++ b/build_in_docker/file_cavity_detection.py
@@ -211,6 +211,30 @@ class OpenJPEG(Tool):
         return self._cmd(OpenJPEG.BIN_DIR / "opj_decompress", container_input_path, container_output_path)
 
 
+class LibJPEG(Tool):
+    BIN_DIR = Path("/polytracker/the_klondike/jpeg-9e")
+
+    def __init__(self, timeout=100):
+        super().__init__(timeout)
+
+    def image_instrumented(self):
+        return "libjpeg"
+
+    def input_extension(self) -> str:
+        return ".jpg"
+
+    def output_extension(self) -> str:
+        return ".bmp"
+
+    def _cmd(self, binary : Path, input: Path, output: Path):
+        return f"{str(binary)} -bmp -outfile {str(output)} {input}"
+
+    def command_instrumented(self, container_input_path: Path, container_output_path: Path) -> str:
+        return self._cmd(LibJPEG.BIN_DIR / "djpeg_track", container_input_path, container_output_path)
+
+    def command_non_instrumented(self, container_input_path: Path, container_output_path: Path) -> str:
+        return self._cmd(LibJPEG.BIN_DIR / "djpeg", container_input_path, container_output_path)
+
 def rename_if_exists(src: Path, dst: Path) -> None:
     if os.path.exists(src):
         rename(src, dst)
@@ -357,6 +381,7 @@ def execute(output_dir: Path, nworkers: Union[None, int], paths: Iterable[Path],
 
 # Maps tool selection argument to functions controlling processing
 TOOL_MAPPING = {
+    "libjpeg": LibJPEG,
     "mutool" : MuTool,
     "openjpeg" : OpenJPEG
 }

--- a/examples/Dockerfile-libjpeg.demo
+++ b/examples/Dockerfile-libjpeg.demo
@@ -1,0 +1,30 @@
+FROM ubuntu:focal AS sources
+
+WORKDIR /polytracker/the_klondike/
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get -y upgrade && apt-get install -y wget
+
+RUN wget http://jpegclub.org/reference/wp-content/uploads/2022/01/jpegsrc.v9e.tar.gz && tar xf jpegsrc.v9e.tar.gz
+WORKDIR jpeg-9e
+
+FROM trailofbits/polytracker:latest
+MAINTAINER Henrik Brodin <henrik.brodin@trailofbits.com>
+
+WORKDIR /polytracker/the_klondike/
+
+COPY --from=sources /polytracker/the_klondike/jpeg-9e /polytracker/the_klondike/jpeg-9e
+
+WORKDIR /polytracker/the_klondike/jpeg-9e
+RUN ./configure  LDFLAGS="-static" && make
+
+#Extract bitcode from mutool
+#WORKDIR /polytracker/the_klondike/jpeg-9e/
+RUN get-bc -b djpeg
+
+#Instrument and link libs
+RUN ${CC} --lower-bitcode --no-control-flow-tracking -i djpeg.bc -o djpeg_track #--libs libjpeg.a # m pthread
+
+# Note, the /workdir directory is intended to be mounted at runtime
+VOLUME ["/workdir"]
+WORKDIR /workdir

--- a/examples/Dockerfile-libjpeg.demo
+++ b/examples/Dockerfile-libjpeg.demo
@@ -19,7 +19,6 @@ WORKDIR /polytracker/the_klondike/jpeg-9e
 RUN ./configure  LDFLAGS="-static" && make
 
 #Extract bitcode from mutool
-#WORKDIR /polytracker/the_klondike/jpeg-9e/
 RUN get-bc -b djpeg
 
 #Instrument and link libs

--- a/examples/Dockerfile-mupdf.demo
+++ b/examples/Dockerfile-mupdf.demo
@@ -11,7 +11,7 @@ RUN git clone --recursive git://git.ghostscript.com/mupdf.git
 WORKDIR /polytracker/the_klondike/mupdf
 RUN git submodule update --init
 
-FROM trailofbits/polytracker
+FROM trailofbits/polytracker:latest
 MAINTAINER Evan Sultanik <evan.sultanik@trailofbits.com>
 
 WORKDIR /polytracker/the_klondike
@@ -20,17 +20,15 @@ COPY --from=sources /polytracker/the_klondike/mupdf /polytracker/the_klondike/mu
 
 WORKDIR /polytracker/the_klondike/mupdf
 RUN git checkout d00de0e96a4a5ec90ffc30837d40cd624a6a89e0
-RUN make -j$((`nproc`+1)) HAVE_X11=no HAVE_GLUT=no prefix=/usr/local build=debug install
+RUN make -j$((`nproc`+1)) HAVE_X11=no HAVE_GLUT=no prefix=/usr/local build=release install
 
-WORKDIR /polytracker/the_klondike/mupdf/build/debug 
+WORKDIR /polytracker/the_klondike/mupdf/build/release
 
 #Extract bitcode from mutool 
 RUN get-bc -b mutool 
 
-#Instrument and link libs
-# RUN ${CC} --instrument-bitcode -i mutool.bc -o mutool_track --libs libmupdf.a m pthread
 # Instrument and Lower the bitcode and link libs 
-RUN ${CC} --lower-bitcode -i mutool.bc -o mutool_track --libs libmupdf.a m pthread
+RUN ${CC} --lower-bitcode --no-control-flow-tracking -i mutool.bc -o mutool_track --libs libmupdf.a m pthread
 
 # Note, the /workdir directory is intended to be mounted at runtime
 VOLUME ["/workdir"]

--- a/examples/Dockerfile-openjpeg.demo
+++ b/examples/Dockerfile-openjpeg.demo
@@ -13,7 +13,7 @@ COPY --from=openjpg-sources /polytracker/the_klondike/openjpeg /polytracker/the_
 
 RUN mkdir -p openjpeg/build
 WORKDIR openjpeg/build
-RUN cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_JPWL:bool=on -DBUILD_MJ2:bool=on
+RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_JPWL:bool=on -DBUILD_MJ2:bool=on
 RUN make install
 WORKDIR bin
 

--- a/examples/build.sh
+++ b/examples/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+POLYTRACKER_ROOT="$( cd "$SCRIPTPATH"/.. >/dev/null 2>&1 ; pwd -P )"
+IMG_BASE="trailofbits/polytracker-demo-"
+DOCKERFILE_BASE="$SCRIPTPATH/Dockerfile-"
+IMAGES=("mupdf" "openjpeg" "libjpeg")
+
+for img in "${IMAGES[@]}"; do
+  docker build -t "$IMG_BASE$img" -f "$DOCKERFILE_BASE$img.demo" $POLYTRACKER_ROOT
+done
+


### PR DESCRIPTION
Builds on #6435.
Adds a script to build docker images for cavity detection/verification with uniform names. Uses the release builds of images to speed up the processing.