### PR TITLE
Work in progress commit for verification of cavities

### DIFF
--- a/build_in_docker/file_cavity_detection.py
+++ b/build_in_docker/file_cavity_detection.py
@@ -1,9 +1,7 @@
 from asyncio import subprocess
 import concurrent.futures
-from hashlib import sha256
 import json
 import os.path
-from re import T
 import subprocess
 import sys
 from abc import ABC, abstractmethod
@@ -12,15 +10,12 @@ from os import mkdir, rename
 from shutil import rmtree
 from pathlib import Path
 from time import time
-from typing import Dict, Iterable, List, Optional, Union
+from typing import Dict, Iterable, List, Union
 from contextlib import contextmanager
 
 
-
-BINDIR = Path(os.path.dirname(os.path.realpath(__file__))) / "bin"
 TIMEOUT = 100
 SCRIPTDIR = Path(os.path.dirname(os.path.realpath(__file__)))
-
 TDAG = "polytracker.tdag"
 RESULTSCSV = "cavities.csv"
 
@@ -237,51 +232,6 @@ class LibJPEG(Tool):
 
     def command_non_instrumented(self, container_input_path: Path, container_output_path: Path) -> str:
         return self._cmd(LibJPEG.BIN_DIR / "djpeg", container_input_path, container_output_path)
-
-class InteractiveRunner:
-    MARKER = "e1eefe9c266415e925638de4dd389e5224e64e93ffadf000ac343479a50ba7e4"
-    def __init__(self, t: Tool, p:subprocess.Popen, indir: Optional[Path] = None, outdir: Optional[Path] = None):
-        self.t = t
-        self.p = p
-        self.indir = indir
-        self.outdir = outdir
-    
-    def run_cmd(self, cmd) -> int:
-        #print(f"cmd: {cmd}")
-        self.p.stdin.write(f"{cmd}\necho $?\necho {InteractiveRunner.MARKER}\n".encode("utf-8"))
-        self.p.stdin.flush()
-        last = ''
-        while True:
-            l = self.p.stdout.readline().rstrip()
-            l = l.decode("utf-8", errors='ignore')
-            #print(f"out: {l}")
-            if l != InteractiveRunner.MARKER:
-                last = l
-            else:
-                ret = int(last)
-                return ret
-
-
-    def exit(self):
-        self.p.stdin.write(b"exit\n")
-        self.p.stdin.flush()
-        self.p.communicate()
-
-
-@contextmanager
-def run_interactive(tool: Tool, indir: Optional[Path] = None, outdir: Optional[Path] = None):
-    args = [x if x != "-t" else "-i" for x in tool.get_docker_run_base()]
-    if indir:
-        args.extend(tool.get_mount_arg(indir, tool.container_input_dir))
-    if outdir:
-        args.extend(tool.get_mount_arg(outdir, tool.container_output_dir))
-    args.append(tool.image_non_instrumented())
-    args.append("/bin/bash")
-    with subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL) as p:
-    #with subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE) as p:
-        ir = InteractiveRunner(tool, p, indir, outdir)
-        yield ir
-        ir.exit()
 
 def rename_if_exists(src: Path, dst: Path) -> None:
     if os.path.exists(src):

--- a/build_in_docker/file_cavity_detection.py
+++ b/build_in_docker/file_cavity_detection.py
@@ -216,7 +216,6 @@ class LibJPEG(Tool):
 
     def image_instrumented(self):
         return "trailofbits/polytracker-demo-libjpeg"
-        return "libjpeg"
 
     def input_extension(self) -> str:
         return ".jpg"

--- a/build_in_docker/file_cavity_detection.py
+++ b/build_in_docker/file_cavity_detection.py
@@ -23,7 +23,7 @@ RESULTSCSV = "cavities.csv"
 class Tool(ABC):
     """Enables interaction with different tools in docker images"""
 
-    def __init__(self, timeout=100):
+    def __init__(self, timeout=TIMEOUT):
         self._timeout = timeout
         self.container_input_dir = Path("/inputs")
         self.container_output_dir = Path("/outputs")
@@ -161,7 +161,7 @@ class Tool(ABC):
 class MuTool(Tool):
     BIN_DIR = Path("/polytracker/the_klondike/mupdf/build/release")
 
-    def __init__(self, timeout=100):
+    def __init__(self, timeout=TIMEOUT):
         super().__init__(timeout)
 
     def image_instrumented(self):
@@ -186,7 +186,7 @@ class MuTool(Tool):
 class OpenJPEG(Tool):
     BIN_DIR = Path("/polytracker/the_klondike/openjpeg/build/bin")
 
-    def __init__(self, timeout=100):
+    def __init__(self, timeout=TIMEOUT):
         super().__init__(timeout)
 
     def image_instrumented(self):
@@ -211,7 +211,7 @@ class OpenJPEG(Tool):
 class LibJPEG(Tool):
     BIN_DIR = Path("/polytracker/the_klondike/jpeg-9e")
 
-    def __init__(self, timeout=100):
+    def __init__(self, timeout=TIMEOUT):
         super().__init__(timeout)
 
     def image_instrumented(self):

--- a/build_in_docker/file_cavity_detection.py
+++ b/build_in_docker/file_cavity_detection.py
@@ -385,6 +385,9 @@ def path_iterator(paths: Iterable[Path]) -> Iterable[Path]:
             yield p
 
 def process_paths(func, paths: Iterable[Path], f, nworkers: Union[None, int] = None, target_qlen:int = 32) -> int:
+    if nworkers and target_qlen < nworkers:
+        target_qlen = nworkers
+
     with concurrent.futures.ThreadPoolExecutor(max_workers=nworkers) as tpe:
         futures = []
         run = True
@@ -424,7 +427,7 @@ def execute(output_dir: Path, nworkers: Union[None, int], paths: Iterable[Path],
         return (file_cavity_detection, file, output_dir, TIMEOUT, tool)
 
     with open(output_dir / RESULTSCSV, "w") as f:
-        return process_paths(enq, paths, f)
+        return process_paths(enq, paths, f, nworkers)
 
 
 # Maps tool selection argument to functions controlling processing

--- a/build_in_docker/mutate_cavities.py
+++ b/build_in_docker/mutate_cavities.py
@@ -1,9 +1,12 @@
 import argparse
+from contextlib import contextmanager
 import csv
 from pathlib import Path
-from random import randbytes, randint
-from typing import Iterable, Tuple, Union
+#from random import randbytes, randint
+from typing import Iterable, Optional, Tuple, Union
 import unittest
+
+import numpy
 
 
 def method_zero(cavity : bytearray) -> bytearray:
@@ -37,12 +40,68 @@ def iter_cavities(filename: Path, cavities_file: Path) -> Iterable[Tuple[int, in
         rdr = csv.reader(f)
         yield from map(lambda x: (int(x[1]), int(x[2])), filter(lambda x: x[0] == filename, rdr))
 
+def iter_cavity_offsets(filename: Path, cavities_file: Path) -> Iterable[int]:
+    """Iterate each offset considered a cavity"""
+    for (first, last) in iter_cavities(filename, cavities_file):
+        for offset in range(first, last+1):
+            yield offset
+
+
+class FileMutatorInfo:
+    def __init__(self, filename: Path, cavities_file: Path):
+        self.file_size = filename.stat().st_size
+        self.cavity_offsets = set(iter_cavity_offsets(filename.name, cavities_file))
+    
+    def is_cavity(self, offset: int):
+        """Checks if a offset in the file is a cavity"""
+        if offset <0 or offset >= self.file_size:
+            raise Exception(f"{offset} is out of bounds for file size {self.file_size}")
+        return offset in self.cavity_offsets
+
+    def sample_non_cavity_bytes(self, fraction: float) -> Iterable[int]:
+        """Samples a fraction of the non-cavity bytes.
+        
+        This produces an iterator that will iterate over a uniformly sampled
+        subset of offsets from the non-cavity offsets in the input file.
+        Fraction is a float where 0.0 means none and 1.0 means all non-cavity offsets.
+        """
+        N = int((self.file_size - len(self.cavity_offsets)) * fraction)
+        n = 0
+        while n < N:
+            offset = numpy.random.randint(0, self.file_size)
+            if not self.is_cavity(offset):
+                n += 1
+                yield offset
+
+
+
 
 def orig_file(filename: Path) -> bytearray:
     """Read contents of the original/input file into memory"""
     with open(filename, "rb") as f:
         return bytearray(f.read())
 
+@contextmanager
+def flip_restore(buffer: bytearray, offset: int):
+    orig = buffer[offset]
+    buffer[offset] = ~orig & 0xff
+    yield buffer
+    buffer[offset] = orig
+
+class FileMutator:
+    """Provides easy methods to mutate a file"""
+    def __init__(self, filename: Path, mutator = method_flip):
+        self.orig_filedata = orig_file(filename)
+        self.mutator = mutator
+
+    def write_mutated(self, offset: int, f):
+        """Write original file, mutated at offset to f"""
+        if offset <0 or offset >= len(self.orig_filedata):
+            raise Exception(f"{offset} is out of bounds for file size {len(self.orig_filedata)}")
+        
+        with flip_restore(self.orig_filedata, offset) as mutated:
+            f.write(mutated)
+            f.flush()
 
 def target_path(filename : Path, target_dir: Path, method : str) -> Path:
     return target_dir / f"{filename.stem}.mut-{method}{filename.suffix}"

--- a/build_in_docker/verify_cavities.py
+++ b/build_in_docker/verify_cavities.py
@@ -1,20 +1,15 @@
 import argparse
 from contextlib import contextmanager
 import json
-from os import unlink
-from re import S
 import shutil
 import subprocess
-from tempfile import NamedTemporaryFile, TemporaryDirectory
-from typing import Dict, Iterable
-from file_cavity_detection import InteractiveRunner, process_paths, run_interactive, TIMEOUT, Tool, TOOL_MAPPING
+from tempfile import TemporaryDirectory
+from file_cavity_detection import process_paths, Tool, TOOL_MAPPING
 from mutate_cavities import FileMutator, FileMutatorInfo, method_mapping, mutate_cavities
 from hashlib import sha256
 from os.path import exists, getsize
 from pathlib import Path
-from shutil import copy
-from sys import argv, stdout
-from time import time
+from sys import stdout
 
 def get_checksum(f: Path) -> str:
     sh = sha256()
@@ -81,34 +76,31 @@ def verify_in_container(inputfile: Path, tool: Tool):
     
     Expects:
     1. the directory hosting this script to be mounted in the container.
-    2. /data to be a directory hosting one file named input.[tool-input-extension]
-       and one file named cavities.csv which include cavities related to this file.
+    2. /data to be a directory hosting one the input file and the
+       cavities.csv which include cavities related to this file.
 
     Main operation:
     1. Creates /work
-    2. Copy input file to /work
-    3. Run the tool and generate the output file including checksum
-    4. Extract file cavity information from cavities.csv
-    5. For all cavity bytes, 
+    2. Run the tool and generate the output file including checksum
+    3. Extract file cavity information from cavities.csv
+    4. For all cavity bytes,
         - generate a mutated version and run the tool,
         - produce output checksum
         - compare checksum and update statistics
-    6. For a subset of non-cavity bytes, do the same as (5)
-    7. Store the statistics to /data/stats.json
+    5. For a subset of non-cavity bytes, do the same as (4)
+    6. Store the statistics to /data/stats.json
     """
     data = Path("/data")
     work = Path("/work")
     # 1
     work.mkdir()
 
-    print(f"Start processing of {inputfile} in docker container")
     with store_stats(data / STATSJSON) as stats:
 
-        # 2
         fm = FileMutator(inputfile)
         output_file = work / f"output{tool.output_extension()}"
 
-        # 3
+        # 2
         subprocess.run(["/bin/bash", "-c", tool.command_non_instrumented(inputfile, output_file)])
         if not output_file.exists():
             stats["error"] = "Original output file could not be generated"
@@ -117,7 +109,7 @@ def verify_in_container(inputfile: Path, tool: Tool):
         orig_checksum = get_checksum(output_file)
         output_file.unlink()
 
-        # 4
+        # 3
         fmi = FileMutatorInfo(inputfile, data/"cavities.csv")
 
         stats["filesize"] = fmi.file_size
@@ -149,12 +141,14 @@ def verify_in_container(inputfile: Path, tool: Tool):
                     mutated_input.unlink()
                     mutated_ouput.unlink()
 
-        # 5
+        # 4
         do_mutation(fmi.cavity_offsets, stats["cavity"])
-        # 6
+        # 5
         do_mutation(fmi.sample_non_cavity_bytes(0.01), stats["non-cavity"])
+    # 6
 
 def start_in_container(inputfile: Path, cavitydb: Path, toolname: str, resultsdir: Path):
+    print(f"Start processing {inputfile}")
     tool = TOOL_MAPPING[toolname]()
     script_dir = Path(__file__).absolute().parent
     with TemporaryDirectory() as datadir:
@@ -170,92 +164,13 @@ def start_in_container(inputfile: Path, cavitydb: Path, toolname: str, resultsdi
         json_path = Path(datadir)/STATSJSON
         json_dst = resultsdir/f"{inputfile.stem}-verification.json"
         json_path.rename(json_dst)
+    print(f"Completed {inputfile}")
 
-
-
-def verify_results(inputfile: Path, cavitydb: Path, method: str, resultsdir: Path, tool : Tool, sample_percentage: float = 0.01):
-    """Verify that detected cavities are correct and that non-cavities influence results
-    
-    Uses a two step process.
-    1. Verify that mutation of each cavity byte in turn produces the same output (equal checksum)
-    2. Sample a subset (sample_percentage) of the non-cavity bytes and mutate them and verifies that
-       the generated output differs.
-    """
-
-    # Pre phase, ensure output file exists, ensure cavities exists, compute output file checksum
-    
-    fmi = FileMutatorInfo(inputfile, cavitydb)
-    fm = FileMutator(inputfile)
-
-    ret = {}
-    ret["orig-input"] = str(inputfile)
-    ret["orig-input-size"] = fmi.file_size
-    if not inputfile.exists():
-        ret["error"] = f"{str(inputfile)} does not exist."
-    if fmi.file_size == 0:
-        ret["error"] = f"{str(inputfile)} is zero bytes."
-        return ret
-
-    orig_output = result_file(inputfile, resultsdir, tool.output_extension())
-    ret["orig-output"] = str(orig_output)
-    if not orig_output.exists():
-        ret["error"] = f"{str(orig_output)} does not exist."
-    if orig_output.stat().st_size == 0:
-        ret["error"] = f"{str(orig_output)} is zero bytes."
-        return ret
-
-    orig_output_checksum = get_checksum(orig_output)
-
-    ret["cavities"] = {"count": 0, "timeouts": 0, "errors": 0, "output_differs": 0}
-    ret["non-cavities"] = {"count": 0, "timeouts": 0, "errors": 0, "output_differs": 0}
-    
-    def run_mutation(ir: InteractiveRunner, offsets: Iterable[int], output_dict: Dict):
-        start = time()
-        for offset in offsets:
-            output_dict["count"] += 1
-            with NamedTemporaryFile(dir=ir.indir, suffix=tool.input_extension()) as f:
-                fpath = Path(f.name)
-                fm.write_mutated(offset, f)
-                #print(f"offset {offset} orig_checksum {get_checksum(inputfile)} mutated {get_checksum(fpath)}")
-
-                container_input = tool.container_input_path(fpath)
-                output_file = result_file(fpath,ir.outdir, tool.output_extension())
-                container_output = tool.container_output_path(output_file)
-
-                cmd = f"timeout {TIMEOUT} {tool.command_non_instrumented(container_input, container_output)}"
-                #cmd = f"cp {container_input} {container_output}"
-                exit_code = ir.run_cmd(cmd)
-                if exit_code == 124:
-                    output_dict["timeouts"] += 1
-                elif exit_code in [125, 126, 127]:
-                    output_dict["errors"] += 1
-
-                if output_file.exists():
-                    csum = get_checksum(output_file)
-                    if csum != orig_output_checksum:
-                        #print(f"CSUMDIFF {csum} vs {orig_output_checksum}")
-                        output_dict["output_differs"] += 1
-                else:
-                    print(f"File doesn't exist")
-                    # Output differs if the output file does not exists (we check for original output above)
-                    output_dict["output_differs"] += 1
-
-                if output_dict["count"] % 100 == 0:
-                    print(f'{str(inputfile)}: {output_dict["count"]/(time()-start)} files/sec')
-
-                if output_file.exists():
-                    output_file.unlink()
-
-    with TemporaryDirectory() as indir, TemporaryDirectory() as outdir, run_interactive(tool, Path(indir), Path(outdir)) as ir:
-        # Phase 1 verify number of cavity mutations producing identical output
-        run_mutation(ir, fmi.cavity_offsets, ret["cavities"])
-
-        # Phase 2 verify a sampled number of non-cavity offsets produce different output
-        run_mutation(ir, fmi.sample_non_cavity_bytes(sample_percentage), ret["non-cavities"])
-
-    # Produce string output
-    return json.dumps(ret, indent=2)
-
+TYPES = {
+    "allcavities": "Mutate all cavities at once, ensure equal output.",
+    "singlebyte": "Mutate all cavity bytes, one byte at a time and verify equal output. " \
+                    "Mutate a subset of non-cavities and report on equal/non-equal output."
+}
 
 def main():
     parser = argparse.ArgumentParser(
@@ -284,6 +199,10 @@ def main():
         "--tool", "-t", type=str, choices=TOOL_MAPPING.keys(), help="Tool to run.", required=True
     )
 
+    type_help = "Type of verification to run: "
+    type_help += ' '.join([f'{k} - {v}' for (k,v) in TYPES.items()])
+    parser.add_argument("--type", help=type_help, choices=TYPES.keys(), default="singlebyte")
+
     args = parser.parse_args()
 
     cavitydb = args.results / "cavities.csv"
@@ -292,17 +211,15 @@ def main():
 
     if args.container:
         verify_in_container(args.inputs[0], tool)
-        return
+    elif args.type == "allcavities":
+        def enq(file: Path):
+            return (verify_cavities, file, cavitydb, args.method, args.results, args.limit, args.skip, tool)
 
-    def enq(file: Path):
-        return (verify_cavities, file, cavitydb, args.method, args.results, args.limit, args.skip, tool)
-
-    #process_paths(enq, args.inputs, stdout)
-
-    def enq_full(file: Path):
-        return (start_in_container, file, cavitydb, args.tool, args.results)
-        #return (verify_results, file, cavitydb, args.method, args.results, tool, 0.005)
-    process_paths(enq_full, args.inputs, stdout)
+        process_paths(enq, args.inputs, stdout)
+    else:
+        def enq_full(file: Path):
+            return (start_in_container, file, cavitydb, args.tool, args.results)
+        process_paths(enq_full, args.inputs, stdout)
 
 
 if __name__ == "__main__":

--- a/build_in_docker/verify_cavities.py
+++ b/build_in_docker/verify_cavities.py
@@ -153,12 +153,12 @@ def start_in_container(inputfile: Path, cavitydb: Path, toolname: str, resultsdi
     script_dir = Path(__file__).absolute().parent
     with TemporaryDirectory() as datadir:
         shutil.copy(inputfile, datadir)
-        cmd = ["docker", "run", "--rm", 
-            "-v", f"{script_dir}:/src",
-            "-v", f"{datadir}:/data",
-            "-v", f"{cavitydb.absolute()}:/data/cavities.csv",
-            tool.image_non_instrumented(),
-            "/usr/bin/python3", "/src/verify_cavities.py", "--container", "--tool", toolname, "--results", "/data", f"/data/{inputfile.name}"]
+        cmd = ["docker", "run", "--rm"]
+        cmd.extend(tool.get_mount_arg(script_dir, "/src"))
+        cmd.extend(tool.get_mount_arg(datadir, "/data"))
+        cmd.extend(tool.get_mount_arg(cavitydb.absolute(), "/data/cavities.csv"))
+        cmd.extend([tool.image_non_instrumented(), "/usr/bin/python3", "/src/verify_cavities.py",
+                    "--container", "--tool", toolname, "--results", "/data", f"/data/{inputfile.name}"])
         subprocess.run(cmd)
 
         json_path = Path(datadir)/STATSJSON

--- a/build_in_docker/verify_cavities.py
+++ b/build_in_docker/verify_cavities.py
@@ -113,6 +113,9 @@ def verify_in_container(inputfile: Path, tool: Tool):
 
         # 3
         fmi = FileMutatorInfo(inputfile, data/"cavities.csv")
+        if any(map(lambda x: x < 0, fmi.cavity_offsets)):
+            stats["error"] = "No cavities detected"
+            return
 
         stats["filesize"] = fmi.file_size
         stats["cavity"] = {}


### PR DESCRIPTION
Enables verification of cavities using two methods:
1. Mutate all cavities at once and ensure equal output.
2. Mutate one byte at a time each of the cavity bytes and ensure equal output. Then, sample 1% of the remaining bytes and record output checksum equality to original file.