### PR TITLE
Fix tracing.py bug

### DIFF
--- a/polytracker/plugins.py
+++ b/polytracker/plugins.py
@@ -86,6 +86,7 @@ from typing import (
     Generic,
     Iterable,
     List,
+    Mapping,
     Optional,
     Tuple,
     Type,
@@ -242,7 +243,7 @@ class Command(AbstractCommand, ABC):
 
 
 def _lookup_class_property(
-    name: str, bases: Iterable[Type], clsdict: Dict[str, Any]
+    name: str, bases: Iterable[Type], clsdict: Mapping[str, Any]
 ) -> Any:
     if name in clsdict:
         return clsdict[name]

--- a/polytracker/tracing.py
+++ b/polytracker/tracing.py
@@ -114,10 +114,10 @@ class TaintedRegion:
         if isinstance(index_or_slice, slice):
             if index_or_slice.step is not None and index_or_slice.step != 1:
                 raise ValueError("TaintedRegion only supports slices with step == 1")
-            start = slice.start
+            start = index_or_slice.start
             if start < 0:
                 start = max(self.length + start, 0)
-            stop = slice.stop
+            stop = index_or_slice.stop
             if stop < 0:
                 stop = self.length + stop
             if start >= stop or start >= self.length or stop <= 0:


### PR DESCRIPTION
Today the GH actions runs started to fail on the Python linting checks. This is due to a new `mypy` version released yesterday (`mypy 0.950`) which detected two issues:

The first one was that, when getting the `start` and `stop` attributes from a `slice` object, the code was actually getting them from the `slice` class (calling `slice.start` instead of `slice_object.start`).

The second was a minor typing error in a `__dict__` attribute (should be `Mapping[..]` instead of `Dict[..]`)

For reference, these were the errors reported by `mypy`:
```
root@c6c5529074d5:/tmp/tmp.9wFNLVmLp4# mypy --python-version 3.8 --ignore-missing-imports polytracker tests
polytracker/plugins.py:251: error: Argument 3 to "_lookup_class_property" has incompatible type "MappingProxyType[str, Any]"; expected "Dict[str, Any]"
polytracker/tracing.py:118: error: Unsupported operand types for > ("int" and "Callable[[slice], Any]")
polytracker/tracing.py:119: error: Incompatible types in assignment (expression has type "int", variable has type "Callable[[slice], Any]")
polytracker/tracing.py:119: error: Unsupported operand types for + ("int" and "Callable[[slice], Any]")
polytracker/tracing.py:121: error: Unsupported operand types for > ("int" and "Callable[[slice], Any]")
polytracker/tracing.py:122: error: Incompatible types in assignment (expression has type "int", variable has type "Callable[[slice], Any]")
polytracker/tracing.py:122: error: Unsupported operand types for + ("int" and "Callable[[slice], Any]")
polytracker/tracing.py:123: error: Unsupported left operand type for >= ("Callable[[slice], Any]")
polytracker/tracing.py:123: error: Unsupported operand types for <= ("int" and "Callable[[slice], Any]")
polytracker/tracing.py:123: error: Unsupported operand types for >= ("int" and "Callable[[slice], Any]")
polytracker/tracing.py:126: error: Unsupported operand types for + ("int" and "Callable[[slice], Any]")
polytracker/tracing.py:126: error: Unsupported left operand type for - ("Callable[[slice], Any]")
Found 12 errors in 2 files (checked 42 source files)
```