### PR TITLE
Use a git submodule for Catch2 dependency

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -10,6 +10,8 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: true
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
@@ -23,8 +25,6 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install setuptools
           pip install .[dev]
-      - name: Update git submodules
-        run: git submodule update --init --recursive
       - name: C++ lint
         run: |
           python third_party/run-clang-format/run-clang-format.py \

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "third_party/indicators"]
 	path = third_party/indicators
 	url = https://github.com/p-ranav/indicators.git
+[submodule "third_party/Catch2"]
+	path = third_party/Catch2
+	url = https://github.com/catchorg/Catch2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,5 +26,8 @@ if(NOT EXISTS "${PROJECT_SOURCE_DIR}/third_party/indicators/CMakeLists.txt")
     message(FATAL_ERROR "git submodule update --init --recursive must be run first to checkout submodules")
 endif()
 
-add_subdirectory(polytracker)
+add_subdirectory(third_party/Catch2)
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/third_party/Catch2/contrib")
 add_subdirectory(third_party/indicators)
+
+add_subdirectory(polytracker)

--- a/polytracker/src/taintdag/test/CMakeLists.txt
+++ b/polytracker/src/taintdag/test/CMakeLists.txt
@@ -1,17 +1,5 @@
 set(CMAKE_CXX_STANDARD 17)
 
-Include(FetchContent)
-
-FetchContent_Declare(
-  Catch2
-  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-  GIT_TAG        v2.13.7
-)
-
-FetchContent_MakeAvailable(Catch2)
-
-
-list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
 include(CTest)
 include(Catch)
 


### PR DESCRIPTION
In order to be consistent with the other dependencies, this makes it so that Catch2 is also a git submodule (instead of getting it via CMake's `FetchContent`)