### PR TITLE
Add spdlog for logging

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "third_party/Catch2"]
 	path = third_party/Catch2
 	url = https://github.com/catchorg/Catch2
+[submodule "third_party/spdlog"]
+	path = third_party/spdlog
+	url = https://github.com/gabime/spdlog

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,5 +29,7 @@ endif()
 add_subdirectory(third_party/Catch2)
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/third_party/Catch2/contrib")
 add_subdirectory(third_party/indicators)
+set(SPDLOG_NO_EXCEPTIONS TRUE)
+add_subdirectory(third_party/spdlog)
 
 add_subdirectory(polytracker)

--- a/polytracker/src/passes/CMakeLists.txt
+++ b/polytracker/src/passes/CMakeLists.txt
@@ -49,7 +49,7 @@ endif(APPLE)
 
 #add_llvm_library(LLVMShit DataFlowSanitizer.cpp BBSplittingPass.cpp)
 add_library(PolytrackerPass SHARED polytracker_pass.cpp bb_splitting_pass.cpp)
-target_link_libraries(PolytrackerPass LLVMPassConfig indicators)
+target_link_libraries(PolytrackerPass PUBLIC LLVMPassConfig PRIVATE indicators spdlog::spdlog_header_only)
 install (TARGETS PolytrackerPass DESTINATION ${POLYTRACK_PASS_DIR})
 add_library(MetadataPass SHARED metadata_pass.cpp)
 target_link_libraries(MetadataPass LLVMPassConfig)

--- a/polytracker/src/passes/bb_splitting_pass.cpp
+++ b/polytracker/src/passes/bb_splitting_pass.cpp
@@ -7,6 +7,7 @@
 
 #include <string>
 
+#include "spdlog/spdlog.h"
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Instructions.h"
 
@@ -53,10 +54,9 @@ void log_function(BasicBlock *bb, const std::optional<std::string> &fname) {
   }
 
   if ((fname || bb->hasName())) {
-    llvm::errs() << " "
-                 << (bb->hasName() ? bb->getName().data() : "Unnamed block");
-    llvm::errs() << " after call to " << (fname.value_or("Unnamed function"))
-                 << "\n";
+    spdlog::debug("{} after call to {}",
+                  bb->hasName() ? bb->getName().data() : "Unnamed block",
+                  fname.value_or("Unnamed function"));
   }
 }
 } // namespace
@@ -83,9 +83,7 @@ BBSplittingPass::analyzeBasicBlock(BasicBlock &basicBlock) const {
       }
       // We need to split this BB into a new one after the call
       auto bb = next->getParent();
-#ifdef DEBUG_INFO
       log_function(bb, get_function_name(call));
-#endif
       newBBs.push_back(bb->splitBasicBlock(next));
     }
   }


### PR DESCRIPTION
## Description
This PR adds [spdlog](https://github.com/gabime/spdlog), a fast, header-only logging library. It also replaces the manual logging inside `PolytrackerPass` with `spdlog` calls. This fixes https://github.com/trailofbits/polytracker/issues/6451

The PR also includes a small refactor of the progress bar code. Using [this](https://github.com/p-ranav/indicators#working-with-iterables), we can get rid of the code that computes the current progress %.

## Details
The logging level is determined by an environment variable. For example, for seeing DEBUG logs:
`SPDLOG_LEVEL=debug ./polybuild_script++ --lower-bitcode ...`

The output looks like this:
#### Debug enabled
<img width="881" alt="image" src="https://user-images.githubusercontent.com/5762120/166463059-ddd5f484-3c3b-4c87-afe7-3228b26aa5fa.png">

#### No debug logs
<img width="885" alt="image" src="https://user-images.githubusercontent.com/5762120/166464034-6f4f4e31-0b7c-4e23-9644-383889b18e2a.png">

