### PR TITLE
Always verify files

### DIFF
--- a/build_in_docker/verify_cavities.py
+++ b/build_in_docker/verify_cavities.py
@@ -113,9 +113,6 @@ def verify_in_container(inputfile: Path, tool: Tool):
 
         # 3
         fmi = FileMutatorInfo(inputfile, data/"cavities.csv")
-        if any(map(lambda x: x < 0, fmi.cavity_offsets)):
-            stats["error"] = "No cavities detected"
-            return
 
         stats["filesize"] = fmi.file_size
         stats["cavity"] = {}
@@ -154,8 +151,12 @@ def verify_in_container(inputfile: Path, tool: Tool):
                     lastprint = t
 
 
-        # 4
-        do_mutation(fmi.cavity_offsets, stats["cavity"])
+        # 4 If there are any cavities, mutate them
+        if any(map(lambda x: x >= 0, fmi.cavity_offsets)):
+            do_mutation(fmi.cavity_offsets, stats["cavity"])
+        else: # Else just invoke with empty arg to get stats
+            do_mutation([], stats["cavity"])
+
         # 5
         do_mutation(fmi.sample_non_cavity_bytes(0.01), stats["non-cavity"])
     # 6


### PR DESCRIPTION
Previous behavior was to abort if no cavities where detected.
This change ensures that statistics is always collected.
If no cavity bytes are detected only the sampled non-cavity bytes are processed.