### PR TITLE
Use blight for wrapping compiler calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__
 .dmypy.json
 .DS_Store
 .vscode
+.idea
 *.db
 *.bc
 *.o

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,5 @@ RUN ninja install
 
 # Setting up build enviornment for targets 
 ENV POLYTRACKER_CAN_RUN_NATIVELY=1
-ENV CC=/polytracker/build/bin/polybuild_script
-ENV CXX=/polytracker/build/bin/polybuild_script++
 ENV PATH=/polytracker/build/bin:$PATH
 ENV DFSAN_OPTIONS="strict_data_dependencies=0"

--- a/README.md
+++ b/README.md
@@ -80,26 +80,25 @@ Type "help" or "commands"
 
 ## Instrumenting a simple C/C++ program
 
-Installing PolyTracker will also install two build scripts: `polybuild` and `polybuild++`.
-These scripts are essentially wrappers around `clang` and `clang++` and have similar arguments.
-In the Docker container, these are mapped to `${CC}` and `${CXX}`. If run from the host system, these scripts will
-automatically and seamlessly perform the build within Docker, if necessary.
+Installing PolyTracker will also install a build script: `polybuild`.
+This script allows the user to run any build command in a modified environment with the right compilers and options to instrument a program.
+If you have a C/C++ target, you can instrument it by invoking `polybuild` and passing the `--instrument-target` before your
+flags:
 
-If you have a C target, you can instrument it by invoking `polybuild` and passing the `--instrument-target` before your
-cflags:
-
-```
+```bash
 polybuild --instrument-target -g -o my_target my_target.c
 ```
 
-Repeat the same steps above for a cxx file by invoking `polybuild++` instead of `polybuild`.
+If run from the host system, this script will automatically and seamlessly perform the build within Docker, if necessary.
 
-For more complex programs that use a build system like autotools or CMake, or generally for programs that have multiple
-compilation units, ensure that the build program uses `polybuild` or `polybuild++` (_e.g._, by setting the `CC` or `CXX`
-environment variable), and compile the program as normal:
+`polybuild` also supports more complex programs that use a build system like autotools or CMake:
 
 ```bash
-$ CC=polybuild make
+polybuild -- cmake .. -DCMAKE_BUILD_TYPE=Release
+polybuild -- ninja
+# or
+polybuild -- ./configure
+polybuild -- make
 ```
 
 Then run this on the resulting binary:

--- a/examples/Dockerfile-mupdf.demo
+++ b/examples/Dockerfile-mupdf.demo
@@ -20,7 +20,7 @@ COPY --from=sources /polytracker/the_klondike/mupdf /polytracker/the_klondike/mu
 
 WORKDIR /polytracker/the_klondike/mupdf
 RUN git checkout d00de0e96a4a5ec90ffc30837d40cd624a6a89e0
-RUN make -j$((`nproc`+1)) HAVE_X11=no HAVE_GLUT=no prefix=/usr/local build=release install
+RUN polybuild_script -- make -j$((`nproc`+1)) HAVE_X11=no HAVE_GLUT=no prefix=/usr/local build=release install
 
 WORKDIR /polytracker/the_klondike/mupdf/build/release
 
@@ -28,7 +28,7 @@ WORKDIR /polytracker/the_klondike/mupdf/build/release
 RUN get-bc -b mutool 
 
 # Instrument and Lower the bitcode and link libs 
-RUN ${CC} --lower-bitcode --no-control-flow-tracking -i mutool.bc -o mutool_track --libs libmupdf.a m pthread
+RUN polybuild_script --lower-bitcode --no-control-flow-tracking -i mutool.bc -o mutool_track --libs libmupdf.a m pthread
 
 # Note, the /workdir directory is intended to be mounted at runtime
 VOLUME ["/workdir"]

--- a/examples/Dockerfile-poppler.demo
+++ b/examples/Dockerfile-poppler.demo
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y libfreetype6-dev libfontconfig1-dev
 
 # Configure
 WORKDIR /polytracker/the_klondike/poppler
-RUN cmake -S . -B build \
+RUN polybuild_script -- cmake -S . -B build \
 	-DCMAKE_BUILD_TYPE=Release \
 	-DBUILD_SHARED_LIBS=OFF \
 	-DBUILD_GTK_TESTS=OFF \
@@ -42,13 +42,13 @@ RUN cmake -S . -B build \
 	-DCMAKE_EXE_LINKER_FLAGS="-pthread"
 
 # Build
-RUN cmake --build build -j$(nproc)
+RUN polybuild_script -- cmake --build build -j$(nproc)
 
 # Extract and instrument pdftotext, other poppler tools should work the same
 WORKDIR /polytracker/the_klondike/poppler/build/utils
 
 RUN get-bc -b pdftotext
-RUN ${CXX} --lower-bitcode -i pdftotext.bc -o pdftotext_track --libs /build_artifacts/libpoppler.a freetype fontconfig pthread --lists freetype fontconfig
+RUN polybuild_script --lower-bitcode -i pdftotext.bc -o pdftotext_track --libs /build_artifacts/libpoppler.a freetype fontconfig pthread --lists freetype fontconfig
 
 RUN get-bc -b pdftops
-RUN ${CXX} --lower-bitcode -i pdftops.bc -o pdftops_track --libs /build_artifacts/libpoppler.a freetype fontconfig pthread --lists freetype fontconfig
+RUN polybuild_script --lower-bitcode -i pdftops.bc -o pdftops_track --libs /build_artifacts/libpoppler.a freetype fontconfig pthread --lists freetype fontconfig

--- a/examples/Dockerfile-qpdf.demo
+++ b/examples/Dockerfile-qpdf.demo
@@ -14,16 +14,18 @@ WORKDIR /polytracker/the_klondike
 COPY --from=qpdf-sources /polytracker/the_klondike/qpdf /polytracker/the_klondike/qpdf
 COPY --from=qpdf-sources /polytracker/the_klondike/jpeg-9e /polytracker/the_klondike/jpeg-9e
 
+RUN apt remove -y --auto-remove libjpeg-dev
 WORKDIR /polytracker/the_klondike/jpeg-9e/build
-RUN ../configure LDFLAGS="-static" && make install -j$(nproc)
+RUN polybuild_script -- ../configure LDFLAGS="-static" --prefix=/usr
+RUN polybuild_script -- make install -j$(nproc)
 
 WORKDIR /polytracker/the_klondike/qpdf
-RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DBUILD_STATIC_LIBS=ON 
-RUN cmake --build build -j$(nproc)
+RUN polybuild_script -- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DBUILD_STATIC_LIBS=ON
+RUN polybuild_script -- cmake --build build -j$(nproc)
 
 #Extract BC 
 WORKDIR /polytracker/the_klondike/qpdf/build/qpdf
 RUN get-bc -o qpdf.bc -b qpdf
 
 #Instrument and build track target
-RUN ${CXX} --lower-bitcode -i qpdf.bc -o qpdf_track --libs ../libqpdf/libqpdf.a atomic z jpeg --lists libz
+RUN polybuild_script --lower-bitcode -i qpdf.bc -o qpdf_track --libs ../libqpdf/libqpdf.a atomic z --lists libz

--- a/polytracker/CMakeLists.txt
+++ b/polytracker/CMakeLists.txt
@@ -24,5 +24,4 @@ endmacro(install_symlink)
 
 install(DIRECTORY DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
 install_symlink(../share/polytracker/bin/polybuild.py ${CMAKE_INSTALL_PREFIX}/bin/polybuild_script)
-install_symlink(../share/polytracker/bin/polybuild.py ${CMAKE_INSTALL_PREFIX}/bin/polybuild_script++)
 install_symlink(../share/polytracker/bin/poly-link.py ${CMAKE_INSTALL_PREFIX}/bin/poly-link)

--- a/polytracker/build.py
+++ b/polytracker/build.py
@@ -13,43 +13,10 @@ class PolyBuild(Command):
     _container: Optional[DockerContainer] = None
 
     def __init_arguments__(self, parser: argparse.ArgumentParser):
-        parser.add_argument(
-            "--c++", action="store_true", help="run polybuild++ in C++ mode"
-        )
         parser.add_argument("args", nargs=argparse.REMAINDER)
 
     def run(self, args: argparse.Namespace):
-        if getattr(args, "c++", False):
-            cmd = "polybuild_script++"
-        else:
-            cmd = "polybuild_script"
-            # Are we trying to compile C++ code without using `polybuild++`?
-            if (
-                sys.stderr.isatty()
-                and sys.stdin.isatty()
-                and any(
-                    arg.strip()[-4:].lower() in (".cpp", ".cxx", ".c++")
-                    for arg in args.args
-                )
-            ):
-                # one of the arguments ends in .cpp, .cxx, or .c++
-                sys.stderr.write(
-                    "It looks like you are trying to compile C++ code.\n"
-                    "This requires `polybuild++`, not `polybuild`!\n"
-                )
-                while True:
-                    sys.stderr.write(
-                        "Would you like to run with `polybuild++` instead? [Yn] "
-                    )
-                    try:
-                        choice = input().lower()
-                    except KeyboardInterrupt:
-                        exit(1)
-                    if choice == "n":
-                        break
-                    elif choice == "y" or choice == "":
-                        cmd = "polybuild_script++"
-                        break
+        cmd = "polybuild_script"
         args = [cmd] + args.args
         if CAN_RUN_NATIVELY:
             return subprocess.call(args)  # type: ignore
@@ -87,11 +54,5 @@ class PolyInst(Command):
 
 def main():
     PolyBuild(argparse.ArgumentParser(add_help=False)).run(
-        argparse.Namespace(args=sys.argv[1:], **{"c++": False})
-    )
-
-
-def main_plus_plus():
-    PolyBuild(argparse.ArgumentParser(add_help=False)).run(
-        argparse.Namespace(args=sys.argv[1:], **{"c++": True})
+        argparse.Namespace(args=sys.argv[1:])
     )

--- a/polytracker/scripts/polybuild.py
+++ b/polytracker/scripts/polybuild.py
@@ -12,7 +12,7 @@
 
   llvm-link the bitcode together into a whole program archive
 
-  Then you can use polybuild(++) --instrument -f program.bc -o output -llib1 -llib2
+  Then you can use polybuild --instrument -f program.bc -o output -llib1 -llib2
 
   It will run opt to instrument your bitcode and then compile/link all instrumentation libraries with clang to create
   your output exec.
@@ -434,7 +434,9 @@ def main():
         polybuild --lower-bitcode -i input.bc -o output --libs pthread
 
     Run normally with gclang/gclang++:
-        polybuild <normal args>
+        polybuild -- clang <normal args>
+    or:
+        polybuild -- clang++ <normal args>
 
     Get bitcode from gclang built executables with get-bc -b
     """

--- a/polytracker/taint_dag.py
+++ b/polytracker/taint_dag.py
@@ -3,7 +3,6 @@ from typing import (
     Union,
     Iterable,
     Iterator,
-    Iterator,
     Optional,
     Dict,
     Tuple,

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,6 @@ def polytracker_version_string() -> str:
 CONSOLE_SCRIPTS = [
     'polytracker = polytracker.__main__:main',
     'polybuild = polytracker.build:main',
-    'polybuild++ = polytracker.build:main_plus_plus'
 ]
 
 with open(README_PATH, "r") as readme:

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ setup(
     packages=find_packages(),
     python_requires=PYTHON_REQUIRES,
     install_requires=[
+        'blight~=0.0.47',
         'cxxfilt~=0.2.2',
         'docker~=4.4.0',
         'graphviz~=0.14.1',

--- a/tests/tracing.py
+++ b/tests/tracing.py
@@ -40,13 +40,15 @@ def polyclang_compile_target(target_name: str) -> int:
         # so if the binary is already here, it means we built it already this run
         return 0
     if target_name.endswith(".cpp"):
-        build_cmd: str = "polybuild++"
+        build_cmd: str = "clang++"
     else:
-        build_cmd = "polybuild"
+        build_cmd = "clang"
     compile_command = [
         "/usr/bin/env",
-        build_cmd,
+        "polybuild",
         "--instrument-target",
+        "--",
+        build_cmd,
         "-g",
         "-o",
         to_native_path(bin_path),


### PR DESCRIPTION
This PR is the initial step for starting to use `blight` in `polytracker`. It removes `polybuild_script` and `polybuild_script++` as `clang` replacements. Whereas before compiling a project with our tooling would effectively run:

```bash
$ export CC=/polytracker/build/bin/polybuild_script
$ export CXX=/polytracker/build/bin/polybuild_script++
$ make install -j$(nproc)
```

Now it's done by running:
```bash
polybuild_script -- make install -j$(nproc)
```

and the compiler wrapping and modifying of arguments is now handled internally by `polybuild_script` using `blight`.

Internally, `polybuild` configures `blight` to do what was done manually before:
- Replace `clang` calls with `gclang`
- Inject compilation flags (like `-fPIC`)
- Remove compilation flags (like `-Werror`)
- When needed, add include/linking directories created by [polytracker-llvm](https://github.com/trailofbits/polytracker-llvm/blob/123f8d2b2bdfcc0d2577e8836f2e893e823037c5/Dockerfile#L131-L148)
- Copy all produced outputs to `$WLLVM_ARTIFACT_STORE`

Note: The `--` after `polybuild_script`:
```bash
polybuild_script -- make install -j$(nproc)
```
is needed so that `polybuild_script` knows where its arguments end, and where the compilation command begins