### PR TITLE
polytracker: fixes for the linter

### DIFF
--- a/polytracker/__init__.py
+++ b/polytracker/__init__.py
@@ -3,8 +3,8 @@ from pkgutil import iter_modules
 from importlib import import_module
 
 # from .database import DBProgramTrace as PolyTrackerTrace
-from .__main__ import main
-from .taint_dag import TDProgramTrace as PolyTrackerTrace
+# from .__main__ import main
+# from .taint_dag import TDProgramTrace as PolyTrackerTrace
 from .polytracker import *
 
 # All of the classes in SUBMODULES_TO_SUBSUME should really be in the top-level `polytracker` module.

--- a/polytracker/__init__.py
+++ b/polytracker/__init__.py
@@ -3,8 +3,8 @@ from pkgutil import iter_modules
 from importlib import import_module
 
 # from .database import DBProgramTrace as PolyTrackerTrace
-# from .__main__ import main
-# from .taint_dag import TDProgramTrace as PolyTrackerTrace
+from .__main__ import main
+from .taint_dag import TDProgramTrace as PolyTrackerTrace
 from .polytracker import *
 
 # All of the classes in SUBMODULES_TO_SUBSUME should really be in the top-level `polytracker` module.

--- a/polytracker/database.py
+++ b/polytracker/database.py
@@ -173,7 +173,6 @@ class DBBasicBlock(Base, BasicBlock):  # type: ignore
     _children: Optional[Set[BasicBlock]] = None
     _predecessors: Optional[Set[BasicBlock]] = None
 
-    @property
     def entries(self) -> Iterator[BasicBlockEntry]:
         return stream_results(
             Session.object_session(self)
@@ -323,6 +322,7 @@ class DBTraceEvent(Base, TraceEvent):  # type: ignore
     def uid(self) -> int:  # type: ignore
         return self.event_id
 
+    @property
     def touched_taint(self) -> bool:
         return bool(self.accessed_labels)
 

--- a/polytracker/mapping.py
+++ b/polytracker/mapping.py
@@ -4,7 +4,7 @@ This module maps input byte offsets to output byte offsets
 
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, List, Set, Tuple, Iterator
+from typing import Dict, Iterator, List, Optional, Set, Tuple
 from tqdm import tqdm
 
 from .plugins import Command
@@ -22,7 +22,7 @@ class InputOutputMapping:
         self.tdfile: TDFile = f
 
     def dfs_walk(
-        self, label: LabelType, seen: Set[LabelType] = None
+        self, label: LabelType, seen: Optional[Set[LabelType]] = None
     ) -> Iterator[Tuple[LabelType, TDNode]]:
         if seen is None:
             seen = set()

--- a/polytracker/taint_dag.py
+++ b/polytracker/taint_dag.py
@@ -273,7 +273,7 @@ class TDTaintOutput(TaintOutput):
         super().__init__(source, output_offset, label)
 
     def taints(self) -> Taints:
-        return super().taints()
+        raise NotImplementedError()
 
 
 class TDProgramTrace(ProgramTrace):
@@ -285,20 +285,20 @@ class TDProgramTrace(ProgramTrace):
         return super().__contains__(uid)
 
     def __getitem__(self, uid: int) -> TraceEvent:
-        return super().__getitem__(uid)
+        raise NotImplementedError()
 
     def __iter__(self) -> Iterator[TraceEvent]:
-        return super().__iter__()
+        raise NotImplementedError()
 
     def __len__(self) -> int:
-        return super().__len__()
+        raise NotImplementedError()
 
     def access_sequence(self) -> Iterator[TaintAccess]:
-        return super().access_sequence()
+        raise NotImplementedError()
 
     @property
     def basic_blocks(self) -> Iterable[BasicBlock]:
-        return super().basic_blocks
+        raise NotImplementedError()
 
     def file_offset(self, node: TaintForestNode) -> ByteOffset:
         assert node.source is not None
@@ -308,23 +308,23 @@ class TDProgramTrace(ProgramTrace):
 
     @property
     def functions(self) -> Iterable[Function]:
-        return super().functions
+        raise NotImplementedError()
 
     def get_event(self, uid: int) -> TraceEvent:
-        return super().get_event(uid)
+        raise NotImplementedError()
 
     def get_function(self, name: str) -> Function:
-        return super().get_function(name)
+        raise NotImplementedError()
 
     def has_event(self, uid: int) -> bool:
-        return super().has_event(uid)
+        raise NotImplementedError()
 
     def has_function(self, name: str) -> bool:
-        return super().has_function(name)
+        raise NotImplementedError()
 
     @property
     def num_accesses(self) -> int:
-        return super().num_accesses
+        raise NotImplementedError()
 
     @property
     def outputs(self) -> Optional[Iterable[Input]]:
@@ -430,7 +430,7 @@ class TDTaintForest(TaintForest):
         self.synth_label_cnt: int = -1
 
     def __getitem__(self, label: int) -> Iterator[TaintForestNode]:
-        return super().__getitem__(label)
+        raise NotImplementedError()
 
     def __len__(self) -> int:
         return len(self.node_cache)

--- a/polytracker/tracing.py
+++ b/polytracker/tracing.py
@@ -876,7 +876,7 @@ class FunctionReturn(ControlFlowEvent):
     @property
     def basic_block(self) -> BasicBlock:
         """The basic block that called `return`. For the return site of the function, use `self.returning_to`"""
-        return super().basic_block
+        raise NotImplementedError()
 
     @property
     def returning_to(self) -> Optional[BasicBlockEntry]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ def run_polytracker(cmd: List[str]) -> None:
 
 
 def build(target: Path, binary: Path) -> None:
-    assert target.exists
+    assert target.exists()
 
     cmd = ["build"]
     if target.suffix == ".cpp":


### PR DESCRIPTION
- pulls out @hbrodin's mypy lint fixes into a separate PR so they can be merged soonest since the linters fail on the plain main branch right now
- experimented with additional changes to make the flake8 errors I was also seeing on __init__.py go away, but oddly flake8 and mypy seem to be nondeterministically fighting over what is "ok" here. Perhaps flake8's not finding implicit dependencies on things imported in __init__ correctly? 