### PR TITLE
Refactor taint sources

### DIFF
--- a/polytracker/include/taintdag/polytracker.h
+++ b/polytracker/include/taintdag/polytracker.h
@@ -20,6 +20,7 @@
 #include "taintdag/string_table.h"
 #include "taintdag/taint.h"
 #include "taintdag/taint_source.h"
+#include "taintdag/util.h"
 
 namespace taintdag {
 
@@ -36,11 +37,11 @@ public:
 
   // Create taint labels representing a read of length starting at offset from
   // fd If no return value, the fd is not tracked.
-  std::optional<taint_range_t>
-  source_taint(int fd, void const *dst, source_offset_t offset, size_t length);
+  std::optional<taint_range_t> source_taint(int fd, void const *dst,
+                                            util::Offset offset, size_t length);
 
   // Just return the taint_range e.g. for return values
-  std::optional<taint_range_t> source_taint(int fd, source_offset_t offset,
+  std::optional<taint_range_t> source_taint(int fd, util::Offset offset,
                                             size_t length);
 
   // Create a new taint source (not a file) and assigns taint labels

--- a/polytracker/src/CMakeLists.txt
+++ b/polytracker/src/CMakeLists.txt
@@ -32,7 +32,8 @@ set(TAINTDAG_SOURCES
     ${TAINTDAG_DIR}/polytracker.cpp
     ${TAINTDAG_DIR}/print.cpp
     ${TAINTDAG_DIR}/fnmapping.cpp
-    ${TAINTDAG_DIR}/fntrace.cpp)
+    ${TAINTDAG_DIR}/fntrace.cpp
+    ${TAINTDAG_DIR}/util.cpp)
 
 add_library(Polytracker STATIC ${POLYTRACKER_SOURCES} ${TAINT_SOURCES}
                                ${TAINTDAG_SOURCES})

--- a/polytracker/src/taint_sources/taint_sources.cpp
+++ b/polytracker/src/taint_sources/taint_sources.cpp
@@ -119,7 +119,7 @@ static ssize_t impl_offset_read_functions(dfsan_label &ret_label, Offset offset,
                                           void *buffer) {
   auto length = Length::from_returned_size(retval);
   taint_source_buffer(fd, buffer, offset, length, ret_label);
-  return ret_val;
+  return retval;
 }
 
 // Implements taint source functions for read/recv-style functions

--- a/polytracker/src/taint_sources/taint_sources.cpp
+++ b/polytracker/src/taint_sources/taint_sources.cpp
@@ -4,6 +4,7 @@
 
 #include "taintdag/error.h"
 #include "taintdag/polytracker.h"
+#include "taintdag/util.h"
 
 #include <algorithm>
 #include <arpa/inet.h>
@@ -35,6 +36,9 @@
 #endif
 
 EARLY_CONSTRUCT_EXTERN_GETTER(taintdag::PolyTracker, polytracker_tdag);
+
+using util::Length;
+using util::Offset;
 
 // To create some label functions
 // Following the libc custom functions from custom.cc
@@ -68,12 +72,87 @@ static FILE *impl_fopen(const char *filename, const char *mode,
   return fd;
 }
 
-static ssize_t impl_pread(int fd, void *buf, size_t count, off_t offset,
-                          dfsan_label *ret_label) {
-  ssize_t ret = pread(fd, buf, count, offset);
-  if (ret > 0)
-    get_polytracker_tdag().source_taint(fd, buf, offset, ret);
-  *ret_label = 0;
+// Wrapper method for tainting a buffer, from source `fd` at `offset` having
+// `length`. If length is invalid nothing happpens.
+static void taint_source_buffer(int fd, void *buff, Offset offset,
+                                Length length, dfsan_label &ret_label) {
+  if (length.valid()) {
+    get_polytracker_tdag().source_taint(fd, buff, offset, *length.value());
+  }
+
+  ret_label = 0;
+}
+
+// Implementation for the `getc`-style function (`getchar`, `getc`, `fgetc`,...)
+// `ret_label` is the label for the return value. It will be assigned the source
+// label (if any), unless EOF is reached. `file` is the file stream to read from
+// `getchar_function` is the current function to implement
+// `getchar_arg` is the optional arg to pass to the getchar_function.
+template <typename F, typename... Args>
+static int impl_getc_style_functions(dfsan_label &ret_label, FILE *file,
+                                     F &&getchar_function,
+                                     Args... getchar_arg) {
+  static_assert(sizeof...(getchar_arg) <= 1,
+                "Expected zero or one argument to the getchar_function");
+
+  auto offset = Offset::from_file(file);
+  int c = getchar_function(getchar_arg...);
+  ret_label = 0;
+  if (c != EOF) {
+    auto tr =
+        get_polytracker_tdag().source_taint(fileno(file), offset, sizeof(char));
+    if (tr) {
+      ret_label = tr.value().first;
+    }
+  }
+  return c;
+}
+
+// Implements taint source functions for read-style functions with known offset.
+// `ret_label` is the label of the return value (will be set to zero)
+// `offset` is the known offset the read happens on
+// `fd` the file descriptor reading from
+// `buffer` the buffer that will be tainted
+// `read_function` is the actual read function (e.g. `read`, `pread`, `recv`)
+// `read_function_args` are the arguments being passed to `read_function`
+template <typename F, typename... Args>
+static ssize_t impl_offset_read_functions(dfsan_label &ret_label, Offset offset,
+                                          int fd, void *buffer,
+                                          F &&read_function,
+                                          Args... read_function_args) {
+  ssize_t ret_val = read_function(read_function_args...);
+  auto length = Length::from_returned_size(ret_val);
+  taint_source_buffer(fd, buffer, offset, length, ret_label);
+  return ret_val;
+}
+
+// Implements taint source functions for read/recv-style functions
+// `ret_label` is the label of the return value (will be set to zero)
+// `fd` the file descriptor reading from
+// `buffer` the buffer that will be tainted
+// `read_function` is the actual read function (e.g. `read`, `pread`, `recv`)
+// `read_function_args` are the arguments being passed to `read_function`
+template <typename F, typename... Args>
+static ssize_t impl_read_recv_functions(dfsan_label &ret_label, int fd,
+                                        void *buffer, F &&read_function,
+                                        Args... read_function_args) {
+  return impl_offset_read_functions(ret_label, Offset::from_fd(fd), fd, buffer,
+                                    std::forward<F>(read_function),
+                                    std::forward<Args>(read_function_args)...);
+}
+
+// Implementation for the `fread`-style functions
+// `ret_label` is the label for the return value. It will be assigned the source
+// label (if any), unless EOF is reached. `file` is the file stream to read from
+// `getchar_function` is the current function to implement
+// `getchar_arg` is the optional arg to pass to the getchar_function.
+template <typename F>
+static size_t impl_fread(F &&fread_function, FILE *fd, void *buff, size_t size,
+                         size_t count, dfsan_label &ret_label) {
+  auto offset = Offset::from_file(fd);
+  size_t ret = fread_function(buff, size, count, fd);
+  auto length = Length::from_returned_size_count(size, ret);
+  taint_source_buffer(fileno(fd), buff, offset, length, ret_label);
   return ret;
 }
 
@@ -146,14 +225,7 @@ EXT_C_FUNC int __dfsw_fclose(FILE *fd, dfsan_label fd_label,
 EXT_C_FUNC ssize_t __dfsw_read(int fd, void *buff, size_t size,
                                dfsan_label fd_label, dfsan_label buff_label,
                                dfsan_label size_label, dfsan_label *ret_label) {
-  long read_start = lseek(fd, 0, SEEK_CUR);
-  ssize_t ret_val = read(fd, buff, size);
-
-  if (ret_val > 0)
-    get_polytracker_tdag().source_taint(fd, buff, read_start, ret_val);
-
-  *ret_label = 0;
-  return ret_val;
+  return impl_read_recv_functions(*ret_label, fd, buff, read, fd, buff, size);
 }
 
 EXT_C_FUNC ssize_t __dfsw_pread(int fd, void *buf, size_t count, off_t offset,
@@ -161,7 +233,8 @@ EXT_C_FUNC ssize_t __dfsw_pread(int fd, void *buf, size_t count, off_t offset,
                                 dfsan_label count_label,
                                 dfsan_label offset_label,
                                 dfsan_label *ret_label) {
-  return impl_pread(fd, buf, count, offset, ret_label);
+  return impl_offset_read_functions(*ret_label, Offset::from_off_t(offset), fd,
+                                    buf, pread, fd, buf, count, offset);
 }
 
 EXT_C_FUNC ssize_t __dfsw_pread64(int fd, void *buf, size_t count, off_t offset,
@@ -169,20 +242,15 @@ EXT_C_FUNC ssize_t __dfsw_pread64(int fd, void *buf, size_t count, off_t offset,
                                   dfsan_label count_label,
                                   dfsan_label offset_label,
                                   dfsan_label *ret_label) {
-  return impl_pread(fd, buf, count, offset, ret_label);
+  return impl_offset_read_functions(*ret_label, Offset::from_off_t(offset), fd,
+                                    buf, pread, fd, buf, count, offset);
 }
 
 EXT_C_FUNC size_t __dfsw_fread(void *buff, size_t size, size_t count, FILE *fd,
                                dfsan_label buf_label, dfsan_label size_label,
                                dfsan_label count_label, dfsan_label fd_label,
                                dfsan_label *ret_label) {
-  long offset = ftell(fd);
-  size_t ret = fread(buff, size, count, fd);
-
-  if (ret > 0)
-    get_polytracker_tdag().source_taint(fileno(fd), buff, offset, ret * size);
-  *ret_label = 0;
-  return ret;
+  return impl_fread(fread, fd, buff, size, count, *ret_label);
 }
 
 EXT_C_FUNC size_t __dfsw_fread_unlocked(void *buff, size_t size, size_t count,
@@ -191,130 +259,61 @@ EXT_C_FUNC size_t __dfsw_fread_unlocked(void *buff, size_t size, size_t count,
                                         dfsan_label count_label,
                                         dfsan_label fd_label,
                                         dfsan_label *ret_label) {
-  long offset = ftell(fd);
-  size_t ret = fread_unlocked(buff, size, count, fd);
-  if (ret > 0)
-    get_polytracker_tdag().source_taint(fileno(fd), buff, offset, ret * size);
-  *ret_label = 0;
-  return ret;
+  return impl_fread(fread_unlocked, fd, buff, size, count, *ret_label);
 }
+
 EXT_C_FUNC int __dfsw_fgetc(FILE *fd, dfsan_label fd_label,
                             dfsan_label *ret_label) {
-  long offset = ftell(fd);
-  int c = fgetc(fd);
-  *ret_label = 0;
-
-  if (c != EOF) {
-    auto tr =
-        get_polytracker_tdag().source_taint(fileno(fd), offset, sizeof(char));
-    if (tr)
-      *ret_label = tr.value().first;
-  }
-  return c;
+  return impl_getc_style_functions(*ret_label, fd, fgetc, fd);
 }
 
 EXT_C_FUNC int __dfsw_fgetc_unlocked(FILE *fd, dfsan_label fd_label,
                                      dfsan_label *ret_label) {
-  long offset = ftell(fd);
-  int c = fgetc_unlocked(fd);
-  *ret_label = 0;
-  if (c != EOF) {
-    auto tr =
-        get_polytracker_tdag().source_taint(fileno(fd), offset, sizeof(char));
-    if (tr)
-      *ret_label = tr.value().first;
-  }
-  return c;
+  return impl_getc_style_functions(*ret_label, fd, fgetc_unlocked, fd);
 }
 
 EXT_C_FUNC int __dfsw__IO_getc(FILE *fd, dfsan_label fd_label,
                                dfsan_label *ret_label) {
-  long offset = ftell(fd);
-  int c = getc(fd);
-  *ret_label = 0;
-  if (c != EOF) {
-    auto tr =
-        get_polytracker_tdag().source_taint(fileno(fd), offset, sizeof(char));
-    if (tr)
-      *ret_label = tr.value().first;
-  }
-  return c;
+  return impl_getc_style_functions(*ret_label, fd, getc, fd);
 }
 
 EXT_C_FUNC int __dfsw_getc(FILE *fd, dfsan_label fd_label,
                            dfsan_label *ret_label) {
-  long offset = ftell(fd);
-  int c = getc(fd);
-  *ret_label = 0;
-  if (c != EOF) {
-    auto tr =
-        get_polytracker_tdag().source_taint(fileno(fd), offset, sizeof(char));
-    if (tr) {
-      *ret_label = tr.value().first;
-    }
-  }
-  return c;
+  return impl_getc_style_functions(*ret_label, fd, getc, fd);
 }
 
 EXT_C_FUNC int __dfsw_getc_unlocked(FILE *fd, dfsan_label fd_label,
                                     dfsan_label *ret_label) {
-  long offset = ftell(fd);
-  int c = getc_unlocked(fd);
-  *ret_label = 0;
-  if (c != EOF) {
-    auto tr =
-        get_polytracker_tdag().source_taint(fileno(fd), offset, sizeof(char));
-    if (tr)
-      *ret_label = tr.value().first;
-  }
-  return c;
+  return impl_getc_style_functions(*ret_label, fd, getc_unlocked, fd);
 }
 
 EXT_C_FUNC int __dfsw_getchar(dfsan_label *ret_label) {
-  long offset = ftell(stdin);
-  int c = getchar();
-  *ret_label = 0;
-  if (c != EOF) {
-    auto tr = get_polytracker_tdag().source_taint(fileno(stdin), offset,
-                                                  sizeof(char));
-    if (tr)
-      *ret_label = tr.value().first;
-  }
-  return c;
+  return impl_getc_style_functions(*ret_label, stdin, getchar);
 }
 
 EXT_C_FUNC int __dfsw_getchar_unlocked(dfsan_label *ret_label) {
-  long offset = ftell(stdin);
-  int c = getchar_unlocked();
-  *ret_label = 0;
-  if (c != EOF) {
-    auto tr = get_polytracker_tdag().source_taint(fileno(stdin), offset,
-                                                  sizeof(char));
-    if (tr)
-      *ret_label = tr.value().first;
-  }
-  return c;
+  return impl_getc_style_functions(*ret_label, stdin, getchar_unlocked);
 }
 
 EXT_C_FUNC char *__dfsw_fgets(char *str, int count, FILE *fd,
                               dfsan_label str_label, dfsan_label count_label,
                               dfsan_label fd_label, dfsan_label *ret_label) {
-  long offset = ftell(fd);
+  auto offset = Offset::from_file(fd);
   char *ret = fgets(str, count, fd);
-
-  if (ret) {
-    size_t len = strlen(ret);
-    get_polytracker_tdag().source_taint(fileno(fd), str, offset, len);
+  auto length = Length::from_returned_string(ret);
+  taint_source_buffer(fileno(fd), str, offset, length, *ret_label);
+  if (length.valid()) {
     *ret_label = str_label;
-  } else {
-    *ret_label = 0;
   }
   return ret;
 }
 
+// TODO (hbrodin): Should this be removed? The call to fgets doesn't seem right,
+// especially then length is sizeof char*, typically eight. In general it is
+// unbounded and the gets-function is deprecated.
 EXT_C_FUNC char *__dfsw_gets(char *str, dfsan_label str_label,
                              dfsan_label *ret_label) {
-  long offset = ftell(stdin);
+  auto offset = Offset::from_file(stdin);
   char *ret = fgets(str, sizeof str, stdin);
 
   if (ret) {
@@ -334,14 +333,10 @@ EXT_C_FUNC ssize_t __dfsw_getdelim(char **lineptr, size_t *n, int delim,
                                    dfsan_label delim_label,
                                    dfsan_label fd_label,
                                    dfsan_label *ret_label) {
-  long offset = ftell(fd);
-  ssize_t ret = getdelim(lineptr, n, delim, fd);
-
-  if (ret != -1) {
-    get_polytracker_tdag().source_taint(fileno(fd), *lineptr, offset, ret);
-  }
-
-  *ret_label = 0;
+  auto offset = Offset::from_file(fd);
+  auto ret = getdelim(lineptr, n, delim, fd);
+  auto length = Length::from_returned_size(ret);
+  taint_source_buffer(fileno(fd), *lineptr, offset, length, *ret_label);
   return ret;
 }
 
@@ -351,14 +346,10 @@ EXT_C_FUNC ssize_t __dfsw___getdelim(char **lineptr, size_t *n, int delim,
                                      dfsan_label delim_label,
                                      dfsan_label fd_label,
                                      dfsan_label *ret_label) {
-  long offset = ftell(fd);
-  ssize_t ret = __getdelim(lineptr, n, delim, fd);
-
-  if (ret != -1) {
-    get_polytracker_tdag().source_taint(fileno(fd), *lineptr, offset, ret);
-  }
-
-  *ret_label = 0;
+  auto offset = Offset::from_file(fd);
+  auto ret = __getdelim(lineptr, n, delim, fd);
+  auto length = Length::from_returned_size(ret);
+  taint_source_buffer(fileno(fd), *lineptr, offset, length, *ret_label);
   return ret;
 }
 
@@ -367,9 +358,10 @@ EXT_C_FUNC void *__dfsw_mmap(void *start, size_t length, int prot, int flags,
                              dfsan_label len_label, dfsan_label prot_label,
                              dfsan_label flags_label, dfsan_label fd_label,
                              dfsan_label offset_label, dfsan_label *ret_label) {
+  auto offs = Offset::from_off_t(offset);
   void *ret = mmap(start, length, prot, flags, fd, offset);
   if (ret != MAP_FAILED) {
-    get_polytracker_tdag().source_taint(fd, ret, offset, length);
+    get_polytracker_tdag().source_taint(fd, ret, offs, length);
   }
 
   *ret_label = 0;
@@ -482,13 +474,8 @@ EXT_C_FUNC ssize_t __dfsw_recv(int socket, void *buff, size_t length, int flags,
                                dfsan_label length_label,
                                dfsan_label flags_label,
                                dfsan_label *ret_label) {
-  ssize_t ret_val = recv(socket, buff, length, flags);
-
-  if (ret_val > 0)
-    get_polytracker_tdag().source_taint(socket, buff, -1, ret_val);
-
-  *ret_label = 0;
-  return ret_val;
+  return impl_read_recv_functions(*ret_label, socket, buff, recv, socket, buff,
+                                  length, flags);
 }
 
 EXT_C_FUNC ssize_t __dfsw_recvfrom(
@@ -497,12 +484,6 @@ EXT_C_FUNC ssize_t __dfsw_recvfrom(
     dfsan_label buffer_label, dfsan_label length_label, dfsan_label flags_label,
     dfsan_label address_label, dfsan_label address_len_label,
     dfsan_label *ret_label) {
-  ssize_t ret_val =
-      recvfrom(socket, buffer, length, flags, address, address_len);
-
-  if (ret_val > 0)
-    get_polytracker_tdag().source_taint(socket, buffer, -1, ret_val);
-
-  *ret_label = 0;
-  return ret_val;
+  return impl_read_recv_functions(*ret_label, socket, buffer, recvfrom, socket,
+                                  buffer, length, flags, address, address_len);
 }

--- a/polytracker/src/taint_sources/taint_sources.cpp
+++ b/polytracker/src/taint_sources/taint_sources.cpp
@@ -99,9 +99,8 @@ static int impl_getc_style_functions(dfsan_label &ret_label, FILE *file,
   int c = getchar_function(getchar_arg...);
   ret_label = 0;
   if (c != EOF) {
-    auto tr =
-        get_polytracker_tdag().source_taint(fileno(file), offset, sizeof(char));
-    if (tr) {
+    if (auto tr = get_polytracker_tdag().source_taint(fileno(file), offset,
+                                                      sizeof(char))) {
       ret_label = tr.value().first;
     }
   }

--- a/polytracker/src/taintdag/polytracker.cpp
+++ b/polytracker/src/taintdag/polytracker.cpp
@@ -74,15 +74,15 @@ taint_range_t PolyTracker::create_source_taint(source_index_t src,
 // per source tracking should be used. This typically happens for stdin, sockets
 // and other streams.
 std::optional<taint_range_t> PolyTracker::source_taint(int fd, void const *mem,
-                                                       source_offset_t offset,
+                                                       util::Offset offset,
                                                        size_t length) {
   if (auto source_index = output_file_.section<Sources>().mapping_idx(fd)) {
-    if (offset < 0) {
-      offset = stream_offsets_.read(*source_index, length);
-    }
+    auto offset_value = offset.valid()
+                            ? *offset.value()
+                            : stream_offsets_.read(*source_index, length);
     return create_source_taint(*source_index,
                                {reinterpret_cast<uint8_t const *>(mem), length},
-                               offset);
+                               offset_value);
   }
   return {};
 }
@@ -93,13 +93,13 @@ std::optional<taint_range_t> PolyTracker::source_taint(int fd, void const *mem,
 // NOTE: If offset < 0, the assumption is made that offsets aren't known and
 // per source tracking should be used. This typically happens for stdin.
 std::optional<taint_range_t>
-PolyTracker::source_taint(int fd, source_offset_t offset, size_t length) {
+PolyTracker::source_taint(int fd, util::Offset offset, size_t length) {
   if (auto source_index = output_file_.section<Sources>().mapping_idx(fd)) {
-    if (offset < 0) {
-      offset = stream_offsets_.read(*source_index, length);
-    }
+    auto offset_value = offset.valid()
+                            ? *offset.value()
+                            : stream_offsets_.read(*source_index, length);
     auto range = output_file_.section<Labels>().create_source_labels(
-        *source_index, offset, length);
+        *source_index, offset_value, length);
     output_file_.section<SourceLabelIndexSection>().set_range(
         BitIndex{range.first}, BitCount{length});
     return range;

--- a/polytracker/src/taintdag/util.cpp
+++ b/polytracker/src/taintdag/util.cpp
@@ -26,7 +26,7 @@ Length Length::from_returned_size(ssize_t retval) {
 
 Length Length::from_returned_size_count(size_t size, size_t nitems) {
 
-  size_t byte_size;
+  size_t byte_size{0};
 
   // NOTE: using clang builtin. Assuming portability is not an issue as we rely
   // heavily on LLVM.

--- a/polytracker/src/taintdag/util.cpp
+++ b/polytracker/src/taintdag/util.cpp
@@ -46,10 +46,11 @@ Length Length::from_returned_size_count(size_t size, size_t nitems) {
 }
 
 Length Length::from_returned_string(char const *str) {
-  if (!str) {
+  if (str) {
+    return Length{std::string_view{str}.length()};
+  } else {
     return Length{};
   }
-  return Length{strlen(str)};
 }
 
 Length::Length(size_t length) : value_{length} {}
@@ -70,8 +71,9 @@ Offset Offset::from_off_t(off_t offset_value) {
   if (offset_value < 0) {
     return Offset{};
   } else if (offset_value > max_source_offset) {
-    // If this path is reached an offset that is larger than can be recorded in
-    // the TDAG structure is encounteed. There is not much to do but bail out.
+    // If this path is reached an offset that is larger than can be recorded
+    // in the TDAG structure is encounteed. There is not much to do but bail
+    // out.
     error_exit("Offset ", offset_value,
                " is larger than maximum offset that can be handled:",
                max_source_offset);

--- a/polytracker/src/taintdag/util.cpp
+++ b/polytracker/src/taintdag/util.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2022-present, Trail of Bits, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed in accordance with the terms specified in
+ * the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+
+#include "taintdag/error.h"
+#include "taintdag/util.h"
+
+using namespace taintdag;
+
+namespace util {
+
+Length Length::from_returned_size(ssize_t retval) {
+  if (retval > 0) {
+    // All positive ssize_t can be represented in size_t
+    return Length{static_cast<size_t>(retval)};
+  }
+  return Length{};
+}
+
+Length Length::from_returned_size_count(size_t size, size_t nitems) {
+
+  size_t byte_size;
+
+  // NOTE: using clang builtin. Assuming portability is not an issue as we rely
+  // heavily on LLVM.
+  static_assert(sizeof(size_t) == sizeof(unsigned long),
+                "Implementation requires size_t is same size as unsigned long");
+  if (__builtin_umull_overflow(size, nitems, &byte_size)) {
+    error_exit("Length size ", size, " nitems ", nitems, " overflows");
+  }
+
+  // Nothing read
+  if (byte_size == 0) {
+    return Length{};
+  }
+
+  // Read ok
+  return Length{byte_size};
+}
+
+Length Length::from_returned_string(char const *str) {
+  if (!str) {
+    return Length{};
+  }
+  return Length{strlen(str)};
+}
+
+Length::Length(size_t length) : value_{length} {}
+
+std::optional<size_t> const &Length::value() const { return value_; }
+
+bool Length::valid() const { return value_.has_value(); }
+
+Offset Offset::from_fd(int fd) {
+  return Offset::from_off_t(lseek(fd, 0, SEEK_CUR));
+}
+
+Offset Offset::from_file(FILE *file) {
+  return Offset::from_off_t(ftello(file));
+}
+
+Offset Offset::from_off_t(off_t offset_value) {
+  if (offset_value < 0) {
+    return Offset{};
+  } else if (offset_value > max_source_offset) {
+    // If this path is reached an offset that is larger than can be recorded in
+    // the TDAG structure is encounteed. There is not much to do but bail out.
+    error_exit("Offset ", offset_value,
+               " is larger than maximum offset that can be handled:",
+               max_source_offset);
+  }
+  return Offset(offset_value);
+}
+
+Offset::Offset(off_t value) : value_(value) {}
+
+std::optional<taintdag::source_offset_t> const &Offset::value() const {
+  return value_;
+}
+
+bool Offset::valid() const { return value_.has_value(); }
+
+} // namespace util


### PR DESCRIPTION
Implements almost all of the wrapped libc-functions in terms of a few methods. The implementation methods uses template to be able to accept functions having different signatures but still doing essentially the same thing.