### PR TITLE
Basic support for assert()

### DIFF
--- a/polytracker/custom_abi/dfsan_abilist.txt
+++ b/polytracker/custom_abi/dfsan_abilist.txt
@@ -154,7 +154,8 @@ fun:llrintl=functional
 
 # Functions that produce an output that does not depend on the input (shadow is
 # zeroed automatically).
-fun:__assert_fail=discard
+fun:__assert_fail=uninstrumented
+fun:__assert_fail=custom
 fun:__ctype_b_loc=discard
 fun:__cxa_atexit=discard
 fun:__errno_location=discard
@@ -547,7 +548,6 @@ fun:__asinl_finite=uninstrumented
 fun:__asprintf=uninstrumented
 fun:__asprintf_chk=uninstrumented
 fun:__assert=uninstrumented
-fun:__assert_fail=uninstrumented
 fun:__assert_perror_fail=uninstrumented
 fun:__atan2_finite=uninstrumented
 fun:__atan2f_finite=uninstrumented

--- a/polytracker/custom_abi/polytracker_abilist.txt
+++ b/polytracker/custom_abi/polytracker_abilist.txt
@@ -154,7 +154,8 @@ fun:llrintl=functional
 
 # Functions that produce an output that does not depend on the input (shadow is
 # zeroed automatically).
-fun:__assert_fail=discard
+fun:__assert_fail=uninstrumented
+fun:__assert_fail=custom
 fun:__ctype_b_loc=discard
 fun:__cxa_atexit=discard
 fun:__errno_location=discard
@@ -548,7 +549,6 @@ fun:__asinl_finite=uninstrumented
 fun:__asprintf=uninstrumented
 fun:__asprintf_chk=uninstrumented
 fun:__assert=uninstrumented
-fun:__assert_fail=uninstrumented
 fun:__assert_perror_fail=uninstrumented
 fun:__atan2_finite=uninstrumented
 fun:__atan2f_finite=uninstrumented

--- a/polytracker/include/taintdag/outputfile.h
+++ b/polytracker/include/taintdag/outputfile.h
@@ -88,7 +88,7 @@ public:
 
   // The FileHeader is constructed at offset zero of the mapped memory (file).
   // It contains the metadata required to parse a TDAG file. Initially each
-  // section is assumed to be allocation_size in size. On destruction of
+  // section is assumed to be 0 bytes in size. On destruction of
   // the OutputFile instance the size field of each section is updated to
   // reflect the actual, used size.
   struct FileHeader {

--- a/polytracker/include/taintdag/outputfile.h
+++ b/polytracker/include/taintdag/outputfile.h
@@ -97,7 +97,7 @@ public:
         (SectionMeta{.tag = Sections::tag,
                      .align = Sections::align_of,
                      .offset = 0,
-                     .size = Sections::allocation_size})...};
+                     .size = 0})...};
   };
 
   OutputFile(std::filesystem::path const &filename)

--- a/tests/test_assert.cpp
+++ b/tests/test_assert.cpp
@@ -1,0 +1,12 @@
+#include <cassert>
+#include <unistd.h>
+
+int main(int argc, char *argv[]) {
+
+  char data[2];
+  read(0, data, sizeof(data));
+
+  // This will terminate the program unexpectedly (tdag sizes might not be updated).
+  assert(data[0] == data[1]);
+
+}

--- a/tests/test_assert.py
+++ b/tests/test_assert.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import subprocess
+import pytest
+from polytracker import taint_dag, PolyTrackerTrace
+from typing import cast
+
+
+@pytest.mark.program_trace("test_assert.cpp")
+def test_assert(instrumented_binary: Path, trace_file: Path):
+    stdin_data = "ab"
+
+    subprocess.run(
+        [str(instrumented_binary)],
+        input=stdin_data.encode("utf-8"),
+        env={"POLYDB": str(trace_file), "POLYTRACKER_STDIN_SOURCE": str(1)},
+    )
+    program_trace = PolyTrackerTrace.load(trace_file)
+    assert isinstance(program_trace, taint_dag.TDProgramTrace)
+
+    tdfile = program_trace.tdfile
+    assert tdfile.label_count == 4
+
+    t1 = cast(taint_dag.TDSourceNode, tdfile.decode_node(1))
+    assert isinstance(t1, taint_dag.TDSourceNode)
+
+    t2 = cast(taint_dag.TDSourceNode, tdfile.decode_node(2))
+    assert isinstance(t2, taint_dag.TDSourceNode)
+
+    t3 = cast(taint_dag.TDSourceNode, tdfile.decode_node(3))
+    assert isinstance(t3, taint_dag.TDRangeNode)
+    assert t3.first == 1
+    assert t3.last == 2


### PR DESCRIPTION
Will intercept the __assert_fail call and call polytracker_end which will update the output file and close it.
At least a partial solution to #6528.