### PR TITLE
Comments out non-functional `polytracker` commands, removes obsoleted package dependecies

### DIFF
--- a/polytracker/datalog.py
+++ b/polytracker/datalog.py
@@ -236,6 +236,7 @@ class DatalogGrammar:
             + [x.val for x in self.clauses]
         )
 
+
 # TODO (msurovic): Re-enable once TDProgramTrace.access_sequence() is implemented
 
 # class ExtractDatalogCommand(CommandExtension[ExtractGrammarCommand]):

--- a/polytracker/datalog.py
+++ b/polytracker/datalog.py
@@ -236,7 +236,6 @@ class DatalogGrammar:
             + [x.val for x in self.clauses]
         )
 
-
 # TODO (msurovic): Re-enable once TDProgramTrace.access_sequence() is implemented
 
 # class ExtractDatalogCommand(CommandExtension[ExtractGrammarCommand]):

--- a/polytracker/datalog.py
+++ b/polytracker/datalog.py
@@ -2,7 +2,7 @@ from argparse import ArgumentParser, Namespace
 from typing import List, Dict, Union
 
 from .grammars import (
-    ExtractGrammarCommand,
+    # ExtractGrammarCommand,
     Terminal,
     ProgramTrace,
     trace_to_grammar,
@@ -236,62 +236,63 @@ class DatalogGrammar:
             + [x.val for x in self.clauses]
         )
 
+# TODO (msurovic): Re-enable once TDProgramTrace.access_sequence() is implemented
 
-class ExtractDatalogCommand(CommandExtension[ExtractGrammarCommand]):
-    name = "datalog"
-    parent_type = ExtractGrammarCommand
-    datalog_grammar: DatalogGrammar
-    datalog_fact_decls: List[DatalogFactDecl]
-    datalog_facts: List[DatalogFact]
-    true_fact_decl: DatalogTrueFactDecl
-    true_facts: List[DatalogTrueFact]
+# class ExtractDatalogCommand(CommandExtension[ExtractGrammarCommand]):
+#     name = "datalog"
+#     parent_type = ExtractGrammarCommand
+#     datalog_grammar: DatalogGrammar
+#     datalog_fact_decls: List[DatalogFactDecl]
+#     datalog_facts: List[DatalogFact]
+#     true_fact_decl: DatalogTrueFactDecl
+#     true_facts: List[DatalogTrueFact]
 
-    def __init_arguments__(self, parser: ArgumentParser):
-        parser.add_argument(
-            "--extract-datalog",
-            "-d",
-            type=str,
-            default=None,
-            help="path to which to optionally save a datalog grammar",
-        )
+#     def __init_arguments__(self, parser: ArgumentParser):
+#         parser.add_argument(
+#             "--extract-datalog",
+#             "-d",
+#             type=str,
+#             default=None,
+#             help="path to which to optionally save a datalog grammar",
+#         )
 
-    def run(self, command: ExtractGrammarCommand, args: Namespace):
-        if len(command.traces) > 1:
-            raise NotImplementedError(
-                "TODO: Add support for generating DataLog grammars from multiple traces"
-            )
-        elif args.extract_datalog is None:
-            return 0
-        trace = command.traces[0]
-        inputs = list(trace.inputs)
-        if len(inputs) != 1:
-            raise NotImplementedError(
-                "TODO: Add support for extracting DataLog grammars from traces with more than "
-                "one input"
-            )
-        data = inputs[0].content
-        self.datalog_grammar = DatalogGrammar(trace)
-        unique_bytes: Dict[int, bool] = {}
-        self.datalog_fact_decls = []
-        self.datalog_facts = []
-        self.true_fact_decl = DatalogTrueFactDecl()
-        self.true_facts = []
-        for i, byte in enumerate(data):
-            # Add another true fact
-            self.true_facts.append(DatalogTrueFact(i))
-            # Declare the new type of byte
-            if byte not in unique_bytes:
-                self.datalog_fact_decls.append(DatalogFactDecl(str(byte)))
-                unique_bytes[byte] = True
-            self.datalog_facts.append(DatalogFact(str(byte), i, i + 1))
-        return 0
+#     def run(self, command: ExtractGrammarCommand, args: Namespace):
+#         if len(command.traces) > 1:
+#             raise NotImplementedError(
+#                 "TODO: Add support for generating DataLog grammars from multiple traces"
+#             )
+#         elif args.extract_datalog is None:
+#             return 0
+#         trace = command.traces[0]
+#         inputs = list(trace.inputs)
+#         if len(inputs) != 1:
+#             raise NotImplementedError(
+#                 "TODO: Add support for extracting DataLog grammars from traces with more than "
+#                 "one input"
+#             )
+#         data = inputs[0].content
+#         self.datalog_grammar = DatalogGrammar(trace)
+#         unique_bytes: Dict[int, bool] = {}
+#         self.datalog_fact_decls = []
+#         self.datalog_facts = []
+#         self.true_fact_decl = DatalogTrueFactDecl()
+#         self.true_facts = []
+#         for i, byte in enumerate(data):
+#             # Add another true fact
+#             self.true_facts.append(DatalogTrueFact(i))
+#             # Declare the new type of byte
+#             if byte not in unique_bytes:
+#                 self.datalog_fact_decls.append(DatalogFactDecl(str(byte)))
+#                 unique_bytes[byte] = True
+#             self.datalog_facts.append(DatalogFact(str(byte), i, i + 1))
+#         return 0
 
-    def __str__(self):
-        facts = "\n".join(
-            [self.true_fact_decl.val]
-            + [x.val + "." for x in self.true_facts]
-            + [x.val for x in self.datalog_fact_decls]
-            + [fact.val for fact in self.datalog_facts]
-        )
-        grammar = self.datalog_grammar.val
-        return f"{facts}\n\n{grammar}"
+#     def __str__(self):
+#         facts = "\n".join(
+#             [self.true_fact_decl.val]
+#             + [x.val + "." for x in self.true_facts]
+#             + [x.val for x in self.datalog_fact_decls]
+#             + [fact.val for fact in self.datalog_facts]
+#         )
+#         grammar = self.datalog_grammar.val
+#         return f"{facts}\n\n{grammar}"

--- a/polytracker/diffing.py
+++ b/polytracker/diffing.py
@@ -456,48 +456,49 @@ class TraceDiff:
             status.write("Traces do not differ")
         return status.getvalue()
 
+# TODO (msurovic): Re-enable once TDProgramTrace.access_sequence() is implemented
 
-class TraceDiffCommand(Command):
-    name = "diff"
-    help = "compute a diff of two program traces"
+# class TraceDiffCommand(Command):
+#     name = "diff"
+#     help = "compute a diff of two program traces"
 
-    def __init_arguments__(self, parser: ArgumentParser):
-        parser.add_argument(
-            "trace1", type=str, help="the output database from the first trace"
-        )
-        parser.add_argument(
-            "trace2", type=str, help="the output database from the second trace"
-        )
-        parser.add_argument(
-            "--image",
-            type=str,
-            default=None,
-            help="path to optionally output a visualization of the" "diff",
-        )
+#     def __init_arguments__(self, parser: ArgumentParser):
+#         parser.add_argument(
+#             "trace1", type=str, help="the output database from the first trace"
+#         )
+#         parser.add_argument(
+#             "trace2", type=str, help="the output database from the second trace"
+#         )
+#         parser.add_argument(
+#             "--image",
+#             type=str,
+#             default=None,
+#             help="path to optionally output a visualization of the" "diff",
+#         )
 
-    def run(self, args: Namespace):
-        from . import PolyTrackerTrace
+#     def run(self, args: Namespace):
+#         from . import PolyTrackerTrace
 
-        trace1 = PolyTrackerTrace.load(args.trace1)
-        trace2 = PolyTrackerTrace.load(args.trace2)
-        diff = TraceDiff(trace1, trace2)
-        print(str(diff))
-        if args.image is not None:
-            diff.to_image().save(args.image)
+#         trace1 = PolyTrackerTrace.load(args.trace1)
+#         trace2 = PolyTrackerTrace.load(args.trace2)
+#         diff = TraceDiff(trace1, trace2)
+#         print(str(diff))
+#         if args.image is not None:
+#             diff.to_image().save(args.image)
 
 
-class TemporalVisualization(Command):
-    name = "temporal"
-    help = "generate an animation of the file accesses in a runtime trace"
+# class TemporalVisualization(Command):
+#     name = "temporal"
+#     help = "generate an animation of the file accesses in a runtime trace"
 
-    def __init_arguments__(self, parser):
-        parser.add_argument("POLYTRACKER_DB", type=str, help="the trace database")
-        parser.add_argument(
-            "OUTPUT_GIF_PATH", type=str, help="the path to which to save the animation"
-        )
+#     def __init_arguments__(self, parser):
+#         parser.add_argument("POLYTRACKER_DB", type=str, help="the trace database")
+#         parser.add_argument(
+#             "OUTPUT_GIF_PATH", type=str, help="the path to which to save the animation"
+#         )
 
-    def run(self, args):
-        from . import PolyTrackerTrace
+#     def run(self, args):
+#         from . import PolyTrackerTrace
 
-        trace = PolyTrackerTrace.load(args.POLYTRACKER_DB)
-        temporal_animation(args.OUTPUT_GIF_PATH, trace)
+#         trace = PolyTrackerTrace.load(args.POLYTRACKER_DB)
+#         temporal_animation(args.OUTPUT_GIF_PATH, trace)

--- a/polytracker/diffing.py
+++ b/polytracker/diffing.py
@@ -456,6 +456,7 @@ class TraceDiff:
             status.write("Traces do not differ")
         return status.getvalue()
 
+
 # TODO (msurovic): Re-enable once TDProgramTrace.access_sequence() is implemented
 
 # class TraceDiffCommand(Command):

--- a/polytracker/diffing.py
+++ b/polytracker/diffing.py
@@ -456,7 +456,6 @@ class TraceDiff:
             status.write("Traces do not differ")
         return status.getvalue()
 
-
 # TODO (msurovic): Re-enable once TDProgramTrace.access_sequence() is implemented
 
 # class TraceDiffCommand(Command):

--- a/polytracker/grammars.py
+++ b/polytracker/grammars.py
@@ -1397,7 +1397,6 @@ def to_dot(graph: DiGraph, comment: Optional[str] = None) -> graphviz.Digraph:
             dot.edge(f"{str(parent)}", f"{str(child)}")
     return dot
 
-
 # TODO (msurovic): Re-enable once TDProgramTrace.functions() is implemented
 
 # class ExtractGrammarCommand(Command):

--- a/polytracker/grammars.py
+++ b/polytracker/grammars.py
@@ -44,6 +44,8 @@ from .tracing import (
     TraceEvent,
 )
 
+from . import PolyTrackerTrace
+
 log = getLogger("grammars")
 
 
@@ -1395,47 +1397,48 @@ def to_dot(graph: DiGraph, comment: Optional[str] = None) -> graphviz.Digraph:
             dot.edge(f"{str(parent)}", f"{str(child)}")
     return dot
 
+# TODO (msurovic): Re-enable once TDProgramTrace.functions() is implemented
 
-class ExtractGrammarCommand(Command):
-    name = "grammar"
-    help = "extract a grammar from one or more program traces"
+# class ExtractGrammarCommand(Command):
+#     name = "grammar"
+#     help = "extract a grammar from one or more program traces"
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.traces: List[ProgramTrace] = []
-        self.grammar: Optional[Grammar] = None
+#     def __init__(self, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+#         self.traces: List[ProgramTrace] = []
+#         self.grammar: Optional[Grammar] = None
 
-    def __init_arguments__(self, parser: ArgumentParser):
-        parser.add_argument(
-            "TRACES",
-            nargs="+",
-            type=str,
-            help="extract a grammar from the provided PolyTracker trace databases",
-        )
-        parser.add_argument(
-            "--simplify", "-s", action="store_true", help="simplify the grammar"
-        )
+#     def __init_arguments__(self, parser: ArgumentParser):
+#         parser.add_argument(
+#             "TRACES",
+#             nargs="+",
+#             type=str,
+#             help="extract a grammar from the provided PolyTracker trace databases",
+#         )
+#         parser.add_argument(
+#             "--simplify", "-s", action="store_true", help="simplify the grammar"
+#         )
 
-    def run(self, args: Namespace):
-        self.traces = []
-        # try:
-        #     for trace_db_path in args.TRACES:
-        #         trace = PolyTrackerTrace.load(trace_db_path)
-        #         # to_dot(trace.cfg).save("cfg.dot")
-        #         # print(f"num nodes {trace.cfg.number_of_nodes()}")
-        #         # if not trace.is_cfg_connected():
-        #         #     roots = list(trace.cfg_roots())
-        #         #     if len(roots) == 0:
-        #         #         log.error(f"Basic block trace of {trace_db_path} has no roots!\n\n")
-        #         #     else:
-        #         #         root_names = "".join(f"\t{r!s}\n" for r in roots)
-        #         #         log.error(
-        #         #             f"Basic block trace of {trace_db_path} has multiple roots:\n{root_names}"
-        #         #         )
-        #         #     exit(1)
-        #         self.traces.append(trace)
-        # except ValueError as e:
-        #     log.error(f"{e!s}\n\n")
-        #     exit(1)
-        self.grammar = extract(self.traces, args.simplify)
-        print(str(self.grammar))
+#     def run(self, args: Namespace):
+#         self.traces = []
+#         try:
+#             for trace_db_path in args.TRACES:
+#                 trace = PolyTrackerTrace.load(trace_db_path)
+#                 # to_dot(trace.cfg).save("cfg.dot")
+#                 # print(f"num nodes {trace.cfg.number_of_nodes()}")
+#                 # if not trace.is_cfg_connected():
+#                 #     roots = list(trace.cfg_roots())
+#                 #     if len(roots) == 0:
+#                 #         log.error(f"Basic block trace of {trace_db_path} has no roots!\n\n")
+#                 #     else:
+#                 #         root_names = "".join(f"\t{r!s}\n" for r in roots)
+#                 #         log.error(
+#                 #             f"Basic block trace of {trace_db_path} has multiple roots:\n{root_names}"
+#                 #         )
+#                 #     exit(1)
+#                 self.traces.append(trace)
+#         except ValueError as e:
+#             log.error(f"{e!s}\n\n")
+#             exit(1)
+#         self.grammar = extract(self.traces, args.simplify)
+#         print(str(self.grammar))

--- a/polytracker/grammars.py
+++ b/polytracker/grammars.py
@@ -1397,6 +1397,7 @@ def to_dot(graph: DiGraph, comment: Optional[str] = None) -> graphviz.Digraph:
             dot.edge(f"{str(parent)}", f"{str(child)}")
     return dot
 
+
 # TODO (msurovic): Re-enable once TDProgramTrace.functions() is implemented
 
 # class ExtractGrammarCommand(Command):

--- a/polytracker/grammars.py
+++ b/polytracker/grammars.py
@@ -44,8 +44,6 @@ from .tracing import (
     TraceEvent,
 )
 
-from . import PolyTrackerTrace
-
 log = getLogger("grammars")
 
 

--- a/polytracker/tracing.py
+++ b/polytracker/tracing.py
@@ -1279,6 +1279,7 @@ class ProgramTrace(ABC):
         except StopIteration:
             return True
 
+
 # TODO (msurovic): Pending integration from different PR
 
 # class TraceCommand(Command):

--- a/polytracker/tracing.py
+++ b/polytracker/tracing.py
@@ -1279,17 +1279,18 @@ class ProgramTrace(ABC):
         except StopIteration:
             return True
 
+# TODO (msurovic): Pending integration from different PR
 
-class TraceCommand(Command):
-    name = "trace"
-    help = "commands related to tracing"
-    parser: ArgumentParser
+# class TraceCommand(Command):
+#     name = "trace"
+#     help = "commands related to tracing"
+#     parser: ArgumentParser
 
-    def __init_arguments__(self, parser: ArgumentParser):
-        self.parser = parser
+#     def __init_arguments__(self, parser: ArgumentParser):
+#         self.parser = parser
 
-    def run(self, args: Namespace):
-        self.parser.print_help()
+#     def run(self, args: Namespace):
+#         self.parser.print_help()
 
 
 def common_parent_directory(*paths: Union[Path, str]) -> Path:
@@ -1303,6 +1304,7 @@ def common_parent_directory(*paths: Union[Path, str]) -> Path:
 
 
 # TODO (hbrodin): Pending integration from different PR
+
 # class RunTraceCommand(Subcommand[TraceCommand]):
 #     name = "run"
 #     help = "run an instrumented binary"

--- a/polytracker/tracing.py
+++ b/polytracker/tracing.py
@@ -1279,7 +1279,6 @@ class ProgramTrace(ABC):
         except StopIteration:
             return True
 
-
 # TODO (msurovic): Pending integration from different PR
 
 # class TraceCommand(Command):

--- a/setup.py
+++ b/setup.py
@@ -107,12 +107,10 @@ setup(
         "docker~=4.4.0",
         "graphviz~=0.14.1",
         "intervaltree~=3.0.2",
-        "matplotlib~=3.3.0",
         "networkx~=2.4",
         "Pillow>=7.2.0",
         "prompt_toolkit~=3.0.8",
         "pygments~=2.7.3",
-        "pydot~=1.4.1",
         "tqdm>=4.59.0",  # We need at least this version to get the `delay` option
         "typing_extensions>=3.7.4.2",
         "types-setuptools~=57.4.9",


### PR DESCRIPTION
PR does as title suggests. The commented out commands might prove useful in the future, but pollute public facing API. The removed python package dependencies are AFAIK completely obsolete.

Merge this PR **after** #6535 