### PR TITLE
picohttpparser file-based harness + Dockerfile

### DIFF
--- a/examples/http/picohttpparser/.dockerignore
+++ b/examples/http/picohttpparser/.dockerignore
@@ -1,0 +1,3 @@
+picohttpparser
+example_picohttpparser
+example_picohttpparser.o

--- a/examples/http/picohttpparser/Dockerfile
+++ b/examples/http/picohttpparser/Dockerfile
@@ -1,0 +1,18 @@
+# Create a separate image with the latest source
+FROM trailofbits/polytracker:latest
+LABEL org.opencontainers.image.authors="lisa.overall@trailofbits.com"
+
+RUN rm -rf /polytracker/examples/http/picohttpparser && mkdir -p /polytracker/examples/jpeg/picohttpparser
+
+WORKDIR /polytracker/examples/http/picohttpparser
+RUN git clone https://github.com/h2o/picohttpparser.git
+COPY Makefile example_picohttpparser.c /polytracker/examples/http/picohttpparser/
+
+# Build and instrument
+RUN polytracker build make -j$((`nproc`+1))
+RUN polytracker instrument-targets --taint --ftrace example_picohttpparser
+RUN mv example_picohttpparser.instrumented example_picohttpparser_track
+
+# Note, the /workdir directory is intended to be mounted at runtime
+VOLUME ["/workdir"]
+WORKDIR /workdir

--- a/examples/http/picohttpparser/Dockerfile
+++ b/examples/http/picohttpparser/Dockerfile
@@ -13,6 +13,6 @@ RUN polytracker build make -j$((`nproc`+1))
 RUN polytracker instrument-targets --taint --ftrace example_picohttpparser
 RUN mv example_picohttpparser.instrumented example_picohttpparser_track
 
-# Note, the /workdir directory is intended to be mounted at runtime
-VOLUME ["/workdir"]
+# Note, the /workdir and /testcase directories are intended to be mounted at runtime
+VOLUME ["/workdir", "/testcase"]
 WORKDIR /workdir

--- a/examples/http/picohttpparser/Dockerfile
+++ b/examples/http/picohttpparser/Dockerfile
@@ -2,7 +2,7 @@
 FROM trailofbits/polytracker:latest
 LABEL org.opencontainers.image.authors="lisa.overall@trailofbits.com"
 
-RUN rm -rf /polytracker/examples/http/picohttpparser && mkdir -p /polytracker/examples/jpeg/picohttpparser
+RUN rm -rf /polytracker/examples/http/picohttpparser && mkdir -p /polytracker/examples/http/picohttpparser
 
 WORKDIR /polytracker/examples/http/picohttpparser
 RUN git clone https://github.com/h2o/picohttpparser.git

--- a/examples/http/picohttpparser/Makefile
+++ b/examples/http/picohttpparser/Makefile
@@ -1,0 +1,18 @@
+.phony: all
+all: example_picohttpparser
+
+picohttpparser:
+	git clone https://github.com/h2o/picohttpparser.git
+
+picohttpparser/picohttpparser.a picohttpparser/picohttpparser.h: picohttpparser
+	cd picohttpparser && gcc -c picohttpparser.c && ar -rc picohttpparser.a picohttpparser.o
+
+example_picohttpparser.o : example_picohttpparser.c picohttpparser/picohttpparser.h
+	$(CC) -Ipicohttpparser -O0 -c $< -o $@
+
+example_picohttpparser : example_picohttpparser.o picohttpparser/picohttpparser.a
+	$(CC) -O0 $^ -o $@
+
+.phony: clean
+clean:
+	rm -rf picohttpparser example_picohttpparser example_picohttpparser.o

--- a/examples/http/picohttpparser/example_picohttpparser.c
+++ b/examples/http/picohttpparser/example_picohttpparser.c
@@ -1,0 +1,76 @@
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+#include "picohttpparser.h"
+
+#define ERROR_IO -1
+#define ERROR_PARSE -2
+#define ERROR_REQUEST_TOO_LONG -3
+
+int parse_http_request(char *fpath) {
+    FILE *infile = fopen(fpath, "rb");
+	unsigned long location = 0;
+	int i = 0;
+        unsigned char *raw_image;
+
+	if(!infile) {
+		printf("Error opening http file %s!\n", fpath);
+		return 128;
+	}
+
+    char buf[4096], *method, *path;
+    int pret, minor_version;
+    struct phr_header headers[100];
+    size_t buflen = 0, prevbuflen = 0, method_len, path_len, num_headers;
+    ssize_t rret;
+
+    while (1) {
+        /* read the request */
+        while ((rret = read(fileno(infile), buf + buflen, sizeof(buf) - buflen)) == -1 && errno == EINTR)
+            ;
+        if (rret <= 0)
+            return ERROR_IO;
+        prevbuflen = buflen;
+        buflen += rret;
+        /* parse the request */
+        num_headers = sizeof(headers) / sizeof(headers[0]);
+        pret = phr_parse_request(buf, buflen, &method, &method_len, &path, &path_len,
+                                &minor_version, headers, &num_headers, prevbuflen);
+        if (pret > 0)
+            break; /* successfully parsed the request */
+        else if (pret == -1)
+            return ERROR_PARSE;
+        /* request is incomplete, continue the loop */
+        assert(pret == -2);
+        if (buflen == sizeof(buf))
+            return ERROR_REQUEST_TOO_LONG;
+    }
+
+    printf("request is %d bytes long\n", pret);
+    printf("method is %.*s\n", (int)method_len, method);
+    printf("path is %.*s\n", (int)path_len, path);
+    printf("HTTP version is 1.%d\n", minor_version);
+    printf("headers:\n");
+    for (i = 0; i != num_headers; ++i) {
+        printf("%.*s: %.*s\n", (int)headers[i].name_len, headers[i].name,
+            (int)headers[i].value_len, headers[i].value);
+    }
+
+    fclose(infile);
+    return 0;
+}
+
+int main(int argc, char *argv[]) {
+    int i;
+    if(argc < 2) {
+        return 1;
+    }
+    for(i=1; i<argc; ++i) {
+        int ret = parse_http_request(argv[i]);
+        if(ret != 0) {
+            return ret;
+        }
+    }
+    return 0;
+}

--- a/examples/http/picohttpparser/example_picohttpparser.sh
+++ b/examples/http/picohttpparser/example_picohttpparser.sh
@@ -14,17 +14,20 @@ if [[ "$(docker images -q trailofbits/polytracker-demo-http-picohttpparser 2>/de
 fi
 
 HOST_PATH=$(realpath "$1")
+BASENAME=$(basename "$HOST_PATH")
 HOST_DIR=$(dirname "$HOST_PATH")
 
 # mount the file if it's not already in /workdir
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 if [[ "$HOST_DIR" == "$SCRIPT_DIR" ]]; then
-	docker run --read-only -ti --rm -e POLYPATH="$1" -e POLYDB="$1.tdag"\
+	docker run --read-only -ti --rm -e POLYPATH="$1" -e POLYDB="$1.tdag" \
 		--mount type=bind,source="$(pwd)",target=/workdir trailofbits/polytracker-demo-http-picohttpparser:latest \
 		/polytracker/examples/http/picohttpparser/example_picohttpparser_track "$1"
 else
-	CONTAINER_PATH=/workdir/$(basename "$1")
-	docker run --read-only -ti --rm -v "$HOST_PATH":"$CONTAINER_PATH" -e POLYPATH="$CONTAINER_PATH" -e POLYDB="$CONTAINER_PATH.tdag"\
-		--mount type=bind,source="$(pwd)",target=/workdir trailofbits/polytracker-demo-http-picohttpparser:latest \
+	CONTAINER_PATH=/testcase/"$BASENAME"
+	docker run --read-only -ti --rm -e POLYPATH="$CONTAINER_PATH" -e POLYDB=/workdir/"$BASENAME".tdag \
+		--mount type=bind,source="$(pwd)",target=/workdir \
+		--mount type=bind,source="$HOST_PATH",target="$CONTAINER_PATH" \
+		trailofbits/polytracker-demo-http-picohttpparser:latest \
 		/polytracker/examples/http/picohttpparser/example_picohttpparser_track "$CONTAINER_PATH"
 fi

--- a/examples/http/picohttpparser/example_picohttpparser.sh
+++ b/examples/http/picohttpparser/example_picohttpparser.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+if [[ "$(docker images -q trailofbits/polytracker 2>/dev/null)" == "" ]]; then
+	docker build -t trailofbits/polytracker -f ../../Dockerfile ../../
+fi
+if [[ "$(docker images -q trailofbits/polytracker-demo-http-picohttpparser 2>/dev/null)" == "" ]]; then
+	docker build -t trailofbits/polytracker-demo-http-picohttpparser .
+fi
+
+docker run --read-only -ti --rm -e POLYPATH="$1" --mount type=bind,source="$(pwd)",target=/workdir trailofbits/polytracker-demo-http-picohttpparser:latest /polytracker/examples/http/picohttpparser/example_picohttpparser "$1"

--- a/examples/http/picohttpparser/example_picohttpparser.sh
+++ b/examples/http/picohttpparser/example_picohttpparser.sh
@@ -20,12 +20,12 @@ HOST_DIR=$(dirname "$HOST_PATH")
 # mount the file if it's not already in /workdir
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 if [[ "$HOST_DIR" == "$SCRIPT_DIR" ]]; then
-	docker run --read-only -ti --rm -e POLYPATH="$1" -e POLYDB="$1.tdag" \
+	docker run --read-only -ti --rm -e POLYPATH="$1" -e POLYDB="$1.tdag" -e POLYTRACKER_STDOUT_SINK=1\
 		--mount type=bind,source="$(pwd)",target=/workdir trailofbits/polytracker-demo-http-picohttpparser:latest \
 		/polytracker/examples/http/picohttpparser/example_picohttpparser_track "$1"
 else
 	CONTAINER_PATH=/testcase/"$BASENAME"
-	docker run --read-only -ti --rm -e POLYPATH="$CONTAINER_PATH" -e POLYDB=/workdir/"$BASENAME".tdag \
+	docker run --read-only -ti --rm -e POLYPATH="$CONTAINER_PATH" -e POLYDB=/workdir/"$BASENAME".tdag -e POLYTRACKER_STDOUT_SINK=1 \
 		--mount type=bind,source="$(pwd)",target=/workdir \
 		--mount type=bind,source="$HOST_PATH",target="$CONTAINER_PATH" \
 		trailofbits/polytracker-demo-http-picohttpparser:latest \

--- a/examples/http/picohttpparser/example_picohttpparser.sh
+++ b/examples/http/picohttpparser/example_picohttpparser.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+if [[ -z "$1" ]]; then
+	echo "Error: no arguments supplied"
+	echo "Usage: ./example_picohttpparser.sh /path/to/raw_http_request"
+	exit 1
+fi
+
 if [[ "$(docker images -q trailofbits/polytracker 2>/dev/null)" == "" ]]; then
 	docker build -t trailofbits/polytracker -f ../../Dockerfile ../../
 fi
@@ -7,4 +13,18 @@ if [[ "$(docker images -q trailofbits/polytracker-demo-http-picohttpparser 2>/de
 	docker build -t trailofbits/polytracker-demo-http-picohttpparser .
 fi
 
-docker run --read-only -ti --rm -e POLYPATH="$1" --mount type=bind,source="$(pwd)",target=/workdir trailofbits/polytracker-demo-http-picohttpparser:latest /polytracker/examples/http/picohttpparser/example_picohttpparser "$1"
+HOST_PATH=$(realpath "$1")
+HOST_DIR=$(dirname "$HOST_PATH")
+
+# mount the file if it's not already in /workdir
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+if [[ "$HOST_DIR" == "$SCRIPT_DIR" ]]; then
+	docker run --read-only -ti --rm -e POLYPATH="$1" -e POLYDB="$1.tdag"\
+		--mount type=bind,source="$(pwd)",target=/workdir trailofbits/polytracker-demo-http-picohttpparser:latest \
+		/polytracker/examples/http/picohttpparser/example_picohttpparser_track "$1"
+else
+	CONTAINER_PATH=/workdir/$(basename "$1")
+	docker run --read-only -ti --rm -v "$HOST_PATH":"$CONTAINER_PATH" -e POLYPATH="$CONTAINER_PATH" -e POLYDB="$CONTAINER_PATH.tdag"\
+		--mount type=bind,source="$(pwd)",target=/workdir trailofbits/polytracker-demo-http-picohttpparser:latest \
+		/polytracker/examples/http/picohttpparser/example_picohttpparser_track "$CONTAINER_PATH"
+fi


### PR DESCRIPTION
- Feedback welcome, particularly with regard to I/O in the harness. 
- I performed local functional testing of the harness by copying some request strings from picohttpparser's `test.c` into Python bytestrings, writing them out to 1 file per request, and running the uninstrumented and instrumented binaries in the Docker container with those files as arguments.