### PR TITLE
Add guards to instrumentation logging functions

### DIFF
--- a/polytracker/src/polytracker/polytracker.cpp
+++ b/polytracker/src/polytracker/polytracker.cpp
@@ -10,7 +10,7 @@
 
 EARLY_CONSTRUCT_EXTERN_GETTER(taintdag::PolyTracker, polytracker_tdag);
 
-bool polytracker_is_initialized = false;
+static bool polytracker_is_initialized = false;
 
 extern "C" taintdag::Functions::index_t
 __polytracker_log_func_entry(char *name, uint16_t len) {

--- a/polytracker/src/polytracker/polytracker.cpp
+++ b/polytracker/src/polytracker/polytracker.cpp
@@ -10,22 +10,37 @@
 
 EARLY_CONSTRUCT_EXTERN_GETTER(taintdag::PolyTracker, polytracker_tdag);
 
+bool polytracker_is_initialized = false;
+
 extern "C" taintdag::Functions::index_t
 __polytracker_log_func_entry(char *name, uint16_t len) {
+  if (!polytracker_is_initialized) {
+    return 0;
+  }
   return get_polytracker_tdag().function_entry({name, len});
 }
 
 extern "C" void
 __polytracker_log_func_exit(taintdag::Functions::index_t func_index) {
+  if (!polytracker_is_initialized) {
+    return;
+  }
   get_polytracker_tdag().function_exit(func_index);
 }
 
 extern "C" dfsan_label __polytracker_union_table(const dfsan_label &l1,
                                                  const dfsan_label &l2) {
+  if (!polytracker_is_initialized) {
+    return 0;
+  }
   return get_polytracker_tdag().union_labels(l1, l2);
 }
 
 extern "C" void __polytracker_log_conditional_branch(dfsan_label label) {
+  if (!polytracker_is_initialized) {
+    return;
+  }
+
   if (label > 0) {
     get_polytracker_tdag().affects_control_flow(label);
   }
@@ -34,10 +49,16 @@ extern "C" void __polytracker_log_conditional_branch(dfsan_label label) {
 extern "C" void
 __dfsw___polytracker_log_conditional_branch(uint64_t conditional,
                                             dfsan_label conditional_label) {
+  if (!polytracker_is_initialized) {
+    return;
+  }
   __polytracker_log_conditional_branch(conditional_label);
 }
 
-extern "C" void __taint_start() { taint_start(); }
+extern "C" void __taint_start() {
+  taint_start();
+  polytracker_is_initialized = true;
+}
 
 extern "C" void __polytracker_taint_argv(int argc, char *argv[]) {
   polytracker::taint_argv(argc, argv);
@@ -46,6 +67,9 @@ extern "C" void __polytracker_taint_argv(int argc, char *argv[]) {
 extern "C" uint64_t __dfsw___polytracker_log_tainted_control_flow(
     uint64_t conditional, uint32_t functionid, dfsan_label conditional_label,
     dfsan_label function_label, dfsan_label *ret_label) {
+  if (!polytracker_is_initialized) {
+    return 0;
+  }
   if (conditional_label > 0) {
     get_polytracker_tdag().log_tainted_control_flow(conditional_label,
                                                     functionid);
@@ -55,9 +79,15 @@ extern "C" uint64_t __dfsw___polytracker_log_tainted_control_flow(
 }
 
 extern "C" void __polytracker_enter_function(uint32_t function_id) {
+  if (!polytracker_is_initialized) {
+    return;
+  }
   get_polytracker_tdag().enter_function(function_id);
 }
 
 extern "C" void __polytracker_leave_function(uint32_t function_id) {
+  if (!polytracker_is_initialized) {
+    return;
+  }
   get_polytracker_tdag().leave_function(function_id);
 }

--- a/tests/test_stdin.cpp
+++ b/tests/test_stdin.cpp
@@ -104,19 +104,19 @@ int main(int argc, char *argv[]) {
   std::string_view method{argv[1]};
 
   if (method == "read") {
-    return stdin_read();
+    stdin_read();
   } else if (method == "fread") {
-    return stdin_fread();
+    stdin_fread();
   } else if (method == "getc") {
-    return stdin_getc();
+    stdin_getc();
   } else if (method == "getc_unlocked") {
-    return stdin_getc_unlocked();
+    stdin_getc_unlocked();
   } else if (method == "getchar") {
-    return stdin_getchar();
+    stdin_getchar();
   } else if (method == "getchar_unlocked") {
-    return stdin_getchar_unlocked();
+    stdin_getchar_unlocked();
   } else if (method == "fgetc") {
-    return stdin_fgetc();
+    stdin_fgetc();
   }
   return 0;
 }

--- a/tests/test_stdin.py
+++ b/tests/test_stdin.py
@@ -18,7 +18,7 @@ def test_stdin_read(instrumented_binary: Path, trace_file: Path, method: str):
         [str(instrumented_binary), method],
         input=stdin_data.encode("utf-8"),
         env={"POLYDB": str(trace_file), "POLYTRACKER_STDIN_SOURCE": str(1)},
-    )
+    ).check_returncode()
     program_trace = polytracker.PolyTrackerTrace.load(trace_file)
 
     # Ensure /dev/stdin is in the list of inputs


### PR DESCRIPTION
This PR adds guards to instrumentation logging functions to logging before all of polytracker's data structures are properly initialized.