### PR TITLE
Example Dockerfile fixes for PolyTracker short tool paper

### DIFF
--- a/examples/Dockerfile-file.demo
+++ b/examples/Dockerfile-file.demo
@@ -3,18 +3,18 @@ MAINTAINER Carson Harmon <carson.harmon@trailofbits.com>
 WORKDIR /polytracker/the_klondike
 
 RUN apt update
-RUN apt-get install automake libtool make python zlib1g-dev git -y
-RUN git clone https://github.com/file/file.git
+RUN apt-get install automake libtool make zlib1g-dev git -y
 
 RUN echo "temp" > /PLACEHOLDER
 ENV POLYPATH=/PLACEHOLDER
 
-#=================================
-WORKDIR file
-RUN autoreconf -f -i
+WORKDIR /polytracker/the_klondike
+RUN git clone https://github.com/file/file.git
+WORKDIR /polytracker/the_klondike/file
+RUN git fetch --tags && \
+    git checkout tags/FILE5_41
+RUN autoreconf -fiv
 RUN ./configure --prefix=/polytracker/the_klondike/bin/ --disable-shared
 RUN polytracker build make -j$((`nproc`+1)) install
-
-WORKDIR /polytracker/the_klondike/bin/bin
 RUN polytracker instrument-targets --taint --ftrace file --ignore-lists libz
 RUN mv file.instrumented file_track

--- a/examples/Dockerfile-libjpeg.demo
+++ b/examples/Dockerfile-libjpeg.demo
@@ -3,7 +3,8 @@ FROM ubuntu:focal AS libjpeg-sources
 WORKDIR /polytracker/the_klondike/
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y upgrade && apt-get install -y wget
-RUN wget http://jpegclub.org/reference/wp-content/uploads/2022/01/jpegsrc.v9e.tar.gz && tar xf jpegsrc.v9e.tar.gz
+RUN wget https://www.ijg.org/files/jpegsrc.v9e.tar.gz && \
+    tar xvf jpegsrc.v9e.tar.gz
 
 # Now, build the libjpeg image using previously downloaded source
 FROM trailofbits/polytracker:latest

--- a/examples/Dockerfile-nitro-nitf.demo
+++ b/examples/Dockerfile-nitro-nitf.demo
@@ -14,7 +14,7 @@ WORKDIR /polytracker/the_klondike/nitro/build
 RUN polytracker build cmake .. \
 	-DCMAKE_C_FLAGS="-w -D_POSIX_C_SOURCE=200809L -DCODA_OSS_NO_is_trivially_copyable" \
 	-DCMAKE_CXX_FLAGS="-w -D_POSIX_C_SOURCE=200809L -DCODA_OSS_NO_is_trivially_copyable" \
-	-DCODA_BUILD_TESTS=OFF
+	-DCODA_BUILD_TESTS=OFF -DENABLE_PYTHON=OFF
 
 RUN polytracker build cmake --build . -j$((`nproc`+1)) --target show_nitf++
 

--- a/examples/Dockerfile-png.demo
+++ b/examples/Dockerfile-png.demo
@@ -15,7 +15,7 @@ RUN sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list
 #Update pkg-config/util-linux (needed for FontConfig)
 RUN apt update
 RUN apt install pkg-config uuid-dev gperf libtool \
-	gettext autopoint autoconf -y
+	gettext autopoint autoconf wget -y
 
 RUN apt-get install python3-dev
 

--- a/examples/Dockerfile-qpdf.demo
+++ b/examples/Dockerfile-qpdf.demo
@@ -4,7 +4,7 @@ WORKDIR /polytracker/the_klondike
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y git wget 
 RUN git clone --depth=1 --branch 11.5 https://github.com/qpdf/qpdf.git
-RUN wget http://jpegclub.org/reference/wp-content/uploads/2022/01/jpegsrc.v9e.tar.gz && tar xf jpegsrc.v9e.tar.gz
+RUN wget https://www.ijg.org/files/jpegsrc.v9e.tar.gz && tar xf jpegsrc.v9e.tar.gz
 
 # Now, build the qpdf image using previously downloaded source
 FROM trailofbits/polytracker:latest

--- a/examples/Dockerfile-xpdf.demo
+++ b/examples/Dockerfile-xpdf.demo
@@ -85,15 +85,13 @@ RUN polytracker build cmake -S .. -B . -DCMAKE_BUILD_TYPE=Release
 RUN polytracker build make -j$(nproc) install
 
 #=================================
-# Extract and instrument each tool of interest
-RUN polytracker extract-bc -o pdftotext.bc xpdf/pdftotext
-RUN polytracker instrument-bc --taint --ftrace pdftotext.bc -o pdftotext.instrumented.bc --ignore-lists freetype fontconfig xml2 libz
-RUN polytracker lower-bc pdftotext.instrumented.bc -t pdftotext -o pdftotext_track
+# Extract and instrument each tool of interest.
+# This should make three instrumented binaries (originals live in the xpdf/ directory):
+# pdftops.instrumented, pdftotext.instrumented, and pdfinfo.instrumented
+# These commands are split up for timing / debugging purposes but you could
+# run them all as one big instrument-targets as well.
+RUN polytracker instrument-targets --taint --ftrace pdftotext --ignore-lists freetype fontconfig xml2 libz
 
-RUN polytracker extract-bc -o pdfinfo.bc xpdf/pdfinfo
-RUN polytracker instrument-bc --taint --ftrace pdfinfo.bc -o pdfinfo.instrumented.bc --ignore-lists freetype fontconfig xml2 libz
-RUN polytracker lower-bc pdfinfo.instrumented.bc -t pdfinfo -o pdfinfo_track
+RUN polytracker instrument-targets --taint --ftrace pdfinfo --ignore-lists freetype fontconfig xml2 libz
 
-RUN polytracker extract-bc -o pdftops.bc xpdf/pdftops
-RUN polytracker instrument-bc --taint --ftrace pdftops.bc -o pdftops.instrumented.bc --ignore-lists freetype fontconfig xml2 libz
-RUN polytracker lower-bc pdftops.instrumented.bc -t pdftops -o pdftops_track
+RUN polytracker instrument-targets --taint --ftrace pdftops --ignore-lists freetype fontconfig xml2 libz

--- a/examples/Dockerfile-xpdf.demo
+++ b/examples/Dockerfile-xpdf.demo
@@ -45,7 +45,7 @@ RUN make -j5 install
 WORKDIR /polytracker/the_klondike
 
 #zlib
-RUN wget https://www.zlib.net/zlib-1.2.11.tar.gz
+RUN wget https://www.zlib.net/fossils/zlib-1.2.11.tar.gz
 RUN tar -xzvf zlib-1.2.11.tar.gz
 WORKDIR zlib-1.2.11
 RUN ./configure --prefix=/usr && make -j$(nproc) test && make -j$(nproc) install

--- a/examples/Dockerfile-xpdf.demo
+++ b/examples/Dockerfile-xpdf.demo
@@ -1,10 +1,12 @@
 FROM trailofbits/polytracker
-MAINTAINER Carson Harmon <carson.harmon@trailofbits.com>
+LABEL org.opencontainers.image.authors="carson.harmon@trailofbits.com,kelly.kaoudis@trailofbits.com"
 
 WORKDIR /polytracker/the_klondike
 
-#Update pkg-config/util-linux (needed for FontConfig)
-RUN apt update && apt install pkg-config \
+# Update pkg-config/util-linux (needed for FontConfig)
+# qt5 is needed for xpdf to build happily.
+RUN apt-get update && apt-get install -y \
+	pkg-config \
 	uuid-dev \
 	gperf \
   wget \
@@ -18,89 +20,80 @@ RUN apt update && apt install pkg-config \
 	cmake \
 	libfreetype6-dev \
 	libxcb-composite0-dev \
-	libxml2-dev -y
+	libxml2-dev \
+	qtbase5-dev
 
-#RUN apt-get install python3-dev
-
-#Fontconfig requires some stuff?
-#RUN apt install pkg-config \libasound2-dev libssl-dev cmake libfreetype6-dev libexpat1-dev libxcb-composite0-dev -y
-#RUN apt install libxml2-dev -y
+WORKDIR /polytracker/the_klondike
+RUN wget https://dl.xpdfreader.com/old/xpdf-4.03.tar.gz
+RUN tar -xvf xpdf-4.03.tar.gz
+ENV build_dir=/polytracker/the_klondike/xpdf-4.03
 
 #=================================
-WORKDIR /polytracker/the_klondike
+WORKDIR $build_dir
 
-#FreeType http://www.linuxfromscratch.org/blfs/view/svn/general/freetype2.html
+# FreeType http://www.linuxfromscratch.org/blfs/view/svn/general/freetype2.html
 RUN wget https://downloads.sourceforge.net/freetype/freetype-2.10.1.tar.xz
 RUN tar -xvf freetype-2.10.1.tar.xz
 
-WORKDIR freetype-2.10.1
+WORKDIR $build_dir/freetype-2.10.1
 
-#Some linux from scratch magic
+# Some linux from scratch magic
 RUN sed -ri "s:.*(AUX_MODULES.*valid):\1:" modules.cfg
 RUN sed -r "s:.*(#.*SUBPIXEL_RENDERING) .*:\1:" -i include/freetype/config/ftoption.h
 RUN ./configure --prefix=/usr --enable-freetype-config
-RUN make -j5 install
+RUN make -j$(nproc) install
 
 #=================================
-WORKDIR /polytracker/the_klondike
+WORKDIR $build_dir
 
-#zlib
+# zlib
 RUN wget https://www.zlib.net/fossils/zlib-1.2.11.tar.gz
 RUN tar -xzvf zlib-1.2.11.tar.gz
-WORKDIR zlib-1.2.11
-RUN ./configure --prefix=/usr && make -j$(nproc) test && make -j$(nproc) install
+WORKDIR $build_dir/zlib-1.2.11
+RUN ./configure --prefix=/usr && \
+   make -j$(nproc) test && \
+   make -j$(nproc) install
 
 #=================================
-WORKDIR /polytracker/the_klondike
+WORKDIR $build_dir
 
-#Libxml2
+# Libxml2
 
-RUN wget http://xmlsoft.org/sources/libxml2-2.9.10.tar.gz
-RUN tar -xvf libxml2-2.9.10.tar.gz
-WORKDIR libxml2-2.9.10
+RUN wget http://xmlsoft.org/sources/libxml2-2.9.11.tar.gz
+RUN tar -xvf libxml2-2.9.11.tar.gz
+WORKDIR $build_dir/libxml2-2.9.11
 RUN ./configure --disable-dependency-tracking --prefix=/usr --with-python=/usr/bin/python3
-RUN make -j5 install
-RUN make install
-
+RUN make -j$(nproc) install
 
 #=================================
-WORKDIR /polytracker/the_klondike
+WORKDIR $build_dir
 
-##Fontconfig (depends on FreeType), note that the linux from scratch version is broken
-#The gitlab version is up to date, and has a PR merged from a year ago with the bug fix
-#https://gitlab.freedesktop.org/fontconfig/fontconfig/merge_requests/2/diffs?commit_id=8208f99fa1676c42bfd8d74de3e9dac5366c150c
+# Fontconfig (depends on FreeType), note that the linux from scratch version is broken
+# The gitlab version is up to date, and has a PR merged from a year ago with the bug fix
+# https://gitlab.freedesktop.org/fontconfig/fontconfig/merge_requests/2/diffs?commit_id=8208f99fa1676c42bfd8d74de3e9dac5366c150c
 
 RUN git clone https://gitlab.freedesktop.org/fontconfig/fontconfig.git
 
-WORKDIR fontconfig
+WORKDIR $build_dir/fontconfig
 RUN ./autogen.sh --sysconfdir=/etc --prefix=/usr --enable-libxml2 --mandir=/usr/share/man
-RUN make -j5 install
+RUN make -j$(nproc) install
 
 #=================================
-WORKDIR /polytracker/the_klondike
-
-RUN wget https://dl.xpdfreader.com/xpdf-4.03.tar.gz
-RUN tar -xvf xpdf-4.03.tar.gz
-WORKDIR xpdf-4.03
-RUN mkdir build
-WORKDIR build
-RUN cmake -DCMAKE_BUILD_TYPE=Release ..
-RUN make -j5 install
+# build, and record the build with Blight
+WORKDIR $build_dir/build
+RUN polytracker build cmake -S .. -B . -DCMAKE_BUILD_TYPE=Release
+RUN polytracker build make -j$(nproc) install
 
 #=================================
-WORKDIR xpdf
+# Extract and instrument each tool of interest
+RUN polytracker extract-bc -o pdftotext.bc xpdf/pdftotext
+RUN polytracker instrument-bc --taint --ftrace pdftotext.bc -o pdftotext.instrumented.bc --ignore-lists freetype fontconfig xml2 libz
+RUN polytracker lower-bc pdftotext.instrumented.bc -t pdftotext -o pdftotext_track
 
-#Extract and instrument pdftotext, other poppler tools should work the same
-RUN get-bc -b pdftotext
-RUN ${CXX} --lower-bitcode -i pdftotext.bc -o pdftotext_track --libs /build_artifacts/libfofi.a /build_artifacts/libgoo.a /build_artifacts/libsplash.a freetype fontconfig pthread --lists freetype fontconfig xml2 libz
+RUN polytracker extract-bc -o pdfinfo.bc xpdf/pdfinfo
+RUN polytracker instrument-bc --taint --ftrace pdfinfo.bc -o pdfinfo.instrumented.bc --ignore-lists freetype fontconfig xml2 libz
+RUN polytracker lower-bc pdfinfo.instrumented.bc -t pdfinfo -o pdfinfo_track
 
-RUN get-bc -b pdfinfo
-RUN ${CXX} --lower-bitcode -i pdfinfo.bc -o pdfinfo_track --libs /build_artifacts/libfofi.a /build_artifacts/libgoo.a /build_artifacts/libsplash.a freetype fontconfig pthread --lists freetype fontconfig xml2 libz
-
-
-RUN get-bc -b pdftops
-RUN ${CXX} --lower-bitcode -i pdtops.bc -o pdftops_track --libs /build_artifacts/libfofi.a /build_artifacts/libgoo.a /build_artifacts/libsplash.a freetype fontconfig pthread --lists freetype fontconfig xml2 libz
-
-# Note, the /workdir directory is intended to be mounted at runtime
-#VOLUME ["/workdir"]
-#WORKDIR /workdir
+RUN polytracker extract-bc -o pdftops.bc xpdf/pdftops
+RUN polytracker instrument-bc --taint --ftrace pdftops.bc -o pdftops.instrumented.bc --ignore-lists freetype fontconfig xml2 libz
+RUN polytracker lower-bc pdftops.instrumented.bc -t pdftops -o pdftops_track

--- a/examples/Dockerfile-xpdf.demo
+++ b/examples/Dockerfile-xpdf.demo
@@ -3,8 +3,9 @@ LABEL org.opencontainers.image.authors="carson.harmon@trailofbits.com,kelly.kaou
 
 WORKDIR /polytracker/the_klondike
 
-# Update pkg-config/util-linux (needed for FontConfig)
-# qt5 is needed for xpdf to build happily.
+# Updating pkg-config/util-linux is needed for FontConfig
+# Note also that qt5 is needed for the cmake build of xpdf
+# (there appears to not be a cmake macro to turn off the build parts that require it)
 RUN apt-get update && apt-get install -y \
 	pkg-config \
 	uuid-dev \


### PR DESCRIPTION
Fixes dead sources links and WORKDIR assumptions, as well as missing dependencies, for some of the example builds. This gave me the ability to build and gather data from the following:

- libpng / Acropalypse demo
- daedalus pdf
- file
- ffmpeg
- jq
- libjpeg
- mupdf
- nitro
- openjpg
- poppler
- qpdf
- xpdf

Remainder that error out for missing dependency or build failure reasons before we get to instrumentation:
- pdfium
- listgen
- daedalus nitf