### PR TITLE
bumps sphinx_rtd_theme version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@ import os
 import platform
 import re
 import sys
-from setuptools import setup, find_packages
 from typing import Optional, Tuple
 
+from setuptools import find_packages, setup
 
 PYTHON_REQUIRES = ">=3.7"
 if sys.platform == "darwin":

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ setup(
             "pytest",
             "flake8",
             "Sphinx",
-            "sphinx_rtd_theme~=0.4.3",
+            "sphinx_rtd_theme>=0.6",
             "types-setuptools",
         ]
     },


### PR DESCRIPTION
Looks like the RTD configuration might not work with the latest version of Sphinx according to https://github.com/readthedocs/sphinx_rtd_theme/issues/1465 so I'm going to see if this works