### PR TITLE
install/setup for hacking process cleanup

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ permissions: read-all
 
 jobs:
   lint:
-    uses: trailofbits/.github/.github/workflows/lint.yml@v0.1.3
+    uses: trailofbits/.github/.github/workflows/lint.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Docker image:
 pip3 install -e ".[dev]" && polytracker docker rebuild
 ```
 
-or pull the latest prebuilt version from DockerHub:
+or just pull the latest prebuilt version from DockerHub:
 
 ```shell-script
 docker pull trailofbits/polytracker:latest
@@ -287,16 +287,16 @@ cd /polytracker/the_klondike/poppler-0.84.0/build/utils
 ./pdfinfo_track some_pdf.pdf
 ```
 
-## Building PolyTracker from Source
+## Hacking on PolyTracker Using the Docker Environment
+Suppose you want to get a little more in-depth in extending the PolyTracker 
+codebase or in working with TDAG traces, and you don't want to mess with your
+local environment by installing an LLVM version that is heavily customized. 
 
-The compilation process for both PolyTracker LLVM and PolyTracker is rather
-fickle, since it involves juggling both instrumented and non-instrumented
-versions of standard library bitcode. We highly recommend using our pre-built
-and tested Docker container if at all possible. Installing the PolyTracker
-Python package on your host system will allow you to seamlessly interact with
-the prebuilt Docker container. Otherwise, to install PolyTracker natively, we
-recommend replicating the install process from the
-[PolyTracker Dockerfile](Dockerfile).
+If you're working in Ubuntu and starting from a relatively clean 22.04 or 24.04 
+base, the [linked Gist](https://gist.github.com/kaoudis/cf412abafea5ca4054c852f9e5905aab) 
+details steps to get a working passthrough version of the PolyTracker base container.
+
+<script src="https://gist.github.com/kaoudis/cf412abafea5ca4054c852f9e5905aab"> </script>
 
 ## Running Tests
 Running both the Python and C++ unit tests should be done inside the PolyTracker 

--- a/README.md
+++ b/README.md
@@ -288,36 +288,42 @@ cd /polytracker/the_klondike/poppler-0.84.0/build/utils
 ```
 
 ## Hacking on PolyTracker Using the Docker Environment
-Suppose you want to get a little more in-depth in extending the PolyTracker 
-codebase or in analysing TDAG traces, and you don't want to mess with your
-local environment by installing an LLVM version that is heavily customized. 
 
-If you're working in Ubuntu and starting from a relatively clean 22.04 or 24.04 
-base, the [linked Gist](https://gist.github.com/kaoudis/cf412abafea5ca4054c852f9e5905aab) 
+Suppose you want to get a little more in-depth in extending the PolyTracker
+codebase or in analysing TDAG traces, and you don't want to mess with your
+local environment by installing an LLVM version that is heavily customized.
+
+If you're working in Ubuntu and starting from a relatively clean 22.04 or 24.04
+base, the [linked Gist](https://gist.github.com/kaoudis/cf412abafea5ca4054c852f9e5905aab)
 details steps to get a working passthrough version of the PolyTracker base container.
-The base container provides a development environment with all dependencies 
-that you can directly work in, or can extend (as we've done in the example 
+The base container provides a development environment with all dependencies
+that you can directly work in, or can extend (as we've done in the example
 Dockerfiles).
 
 <script src="https://gist.github.com/kaoudis/cf412abafea5ca4054c852f9e5905aab"> </script>
 
 ## Running Tests
-Running both the Python and C++ unit tests should be done inside the PolyTracker 
+
+Running both the Python and C++ unit tests should be done inside the PolyTracker
 Docker container.
 
-The Catch2 unit tests in `unittests/` live in 
-`/polytracker-build/unittests/src/taintdag/` within the container. Run the test binary 
+The Catch2 unit tests in `unittests/` live in
+`/polytracker-build/unittests/src/taintdag/` within the container. Run the test binary
 within the Docker container with
+
 ```shell-script
   cd /polytracker-build/unittests/src/taintdag/ && ./tests-taintdag
 ```
 
-The Python unit tests in `tests/` require local test C++ programs that the test 
+The Python unit tests in `tests/` require local test C++ programs that the test
 fixtures will instrument. Run them using Pytest in the working
+
 ```shell-script
   pytest tests
 ```
+
 Or use pytest to run a single test file with
+
 ```shell-script
   pytest tests/test_foo.py
 ```

--- a/README.md
+++ b/README.md
@@ -289,12 +289,15 @@ cd /polytracker/the_klondike/poppler-0.84.0/build/utils
 
 ## Hacking on PolyTracker Using the Docker Environment
 Suppose you want to get a little more in-depth in extending the PolyTracker 
-codebase or in working with TDAG traces, and you don't want to mess with your
+codebase or in analysing TDAG traces, and you don't want to mess with your
 local environment by installing an LLVM version that is heavily customized. 
 
 If you're working in Ubuntu and starting from a relatively clean 22.04 or 24.04 
 base, the [linked Gist](https://gist.github.com/kaoudis/cf412abafea5ca4054c852f9e5905aab) 
 details steps to get a working passthrough version of the PolyTracker base container.
+The base container provides a development environment with all dependencies 
+that you can directly work in, or can extend (as we've done in the example 
+Dockerfiles).
 
 <script src="https://gist.github.com/kaoudis/cf412abafea5ca4054c852f9e5905aab"> </script>
 

--- a/README.md
+++ b/README.md
@@ -300,8 +300,6 @@ The base container provides a development environment with all dependencies
 that you can directly work in, or can extend (as we've done in the example
 Dockerfiles).
 
-<script src="https://gist.github.com/kaoudis/cf412abafea5ca4054c852f9e5905aab"> </script>
-
 ## Running Tests
 
 Running both the Python and C++ unit tests should be done inside the PolyTracker

--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,7 @@ setup(
         "Pillow>=7.2.0",
         "prompt_toolkit~=3.0.8",
         "pygments~=2.15.0",
+        "setuptools>=75.8.0",
         "tqdm>=4.59.0",  # We need at least this version to get the `delay` option
         "typing_extensions>=3.7.4.2",
         "types-setuptools~=57.4.9",


### PR DESCRIPTION
- adds setuptools to requirements to fix the error `ModuleNotFoundError: No module named 'distutils'` that occurs on build otherwise with current Python 3.12
- links setup-from-clean gist detailing what I know of as the quickest way to get to a working programming environment to the readme (this is a gist so it can be easily curled and run, or/and just pulled as a startup script)
- links to updated trunk version fixed in https://github.com/trailofbits/.github/pull/28 so that all builds don't fail on the trunk lint action anymore