### PR TITLE
Migrate to Trusted Publishing

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -1,31 +1,60 @@
-# This workflows will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
-
-name: Upload Python Package
-
 on:
   release:
-    types: [published]
+    types:
+      - published
+
+name: release
+
+permissions: {}
 
 jobs:
-  deploy:
-    runs-on: ubuntu-22.04
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
     timeout-minutes: 32
-
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.x
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          # trunk-ignore(yamllint/quoted-strings)
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel
+
+      - name: Build distributions
+        run: |
+          python setup.py sdist bdist_wheel
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: distributions
+          path: dist/
+
+  publish:
+    name: Publish Python distributions to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/polytracker
+    needs: [build]
+    permissions:
+      # Used to sign the release's artifacts with sigstore-python.
+      # Used to publish to PyPI with Trusted Publishing.
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: distributions
+          path: dist/
+
+      - name: Publish distributions
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -6,3 +6,4 @@
 plugins
 user_trunk.yaml
 user.yaml
+tmp

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,44 +1,44 @@
 version: 0.1
 cli:
-  version: 1.14.1
+  version: 1.25.0
 plugins:
   sources:
     - id: trunk
-      ref: v1.2.1
+      ref: v1.10.0
       uri: https://github.com/trunk-io/plugins
 runtimes:
   enabled:
-    - go@1.19.5
-    - node@18.12.1
-    - python@3.10.8
+    - go@1.21.0
+    - node@22.16.0
+    - python@3.14.4
 lint:
   ignore:
     - linters: [ALL]
       paths:
         - polytracker/src/compiler-rt/**
   enabled:
-    - taplo@0.8.1
-    - actionlint@1.6.25
-    - bandit@1.7.5
-    - black@23.7.0
-    - checkov@2.4.5
+    - taplo@0.10.0
+    - actionlint@1.7.12
+    - bandit@1.9.4
+    - black@26.5.1
+    - checkov@3.2.529
     - clang-format@16.0.3
-    - flake8@6.1.0
+    - flake8@7.3.0
     - git-diff-check
-    - hadolint@2.12.0
-    - isort@5.12.0
-    - markdownlint@0.35.0
-    - mypy@1.5.1
-    - oxipng@8.0.0
-    - prettier@3.0.2
-    - ruff@0.0.285
-    - shellcheck@0.9.0
+    - hadolint@2.14.0
+    - isort@8.0.1
+    - markdownlint@0.48.0
+    - mypy@2.1.0
+    - oxipng@10.1.1
+    - prettier@3.8.3
+    - ruff@0.15.14
+    - shellcheck@0.11.0
     - shfmt@3.6.0
-    - svgo@3.0.2
-    - terrascan@1.18.3
-    - trivy@0.44.1
-    - trufflehog@3.48.0
-    - yamllint@1.32.0
+    - svgo@4.0.1
+    - terrascan@1.19.9
+    - trivy@0.70.0
+    - trufflehog@3.95.3
+    - yamllint@1.38.0
 actions:
   disabled:
     - trunk-announce


### PR DESCRIPTION
This PR adapts the PyPI publishing workflow to use Trusted Publishing. It's based on our [template](https://github.com/trailofbits/cookiecutter-python/blob/main/%7B%7Bcookiecutter.project_slug%7D%7D/.github/workflows/release.yml), but leaving the build invocation the same for now.

I've also created the corresponding trusted publisher on PyPI:
<img width="604" height="122" alt="image" src="https://github.com/user-attachments/assets/422a3e95-6424-4d20-9a4e-8b9c36b99a36" />
